### PR TITLE
Drop generated libraries from dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,30 +17,6 @@ updates:
       prefix: "chore"
       include: "scope"
 
-  - package-ecosystem: "npm"
-    directory: "/gen/nominatim"
-    schedule:
-      interval: "daily"
-    commit-message:
-      prefix: "chore"
-      include: "scope"
-
-  - package-ecosystem: "npm"
-    directory: "/gen/geojs"
-    schedule:
-      interval: "daily"
-    commit-message:
-      prefix: "chore"
-      include: "scope"
-
-  - package-ecosystem: "npm"
-    directory: "/gen/met.no"
-    schedule:
-      interval: "daily"
-    commit-message:
-      prefix: "chore"
-      include: "scope"
-
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
These should be managed by openapi-generator-cli, not dependabot.