### PR TITLE
dependabot: Group updates to @middy/* and dev dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,19 +3,41 @@ version: 2
 updates:
   - package-ecosystem: "npm"
     directory: "/"
+
     schedule:
       interval: "daily"
+
     commit-message:
       prefix: "chore"
       include: "scope"
 
+    groups:
+      middy:
+        patterns:
+          - "@middy/*"
+
+      dev-dependencies:
+        applies-to: "version-updates"
+        dependency-type: "development"
+
   - package-ecosystem: "npm"
     directory: "/app"
+
     schedule:
       interval: "daily"
+
     commit-message:
       prefix: "chore"
       include: "scope"
+
+    groups:
+      middy:
+        patterns:
+          - "@middy/*"
+
+      dev-dependencies:
+        applies-to: "version-updates"
+        dependency-type: "development"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
To reduce the number of PRs to consider, and since middy updates might come as a batch.