### PR TITLE
CI/test-lint: Run yarn with `--frozen-lockfile`

### DIFF
--- a/.github/workflows/test-lint.yml
+++ b/.github/workflows/test-lint.yml
@@ -19,7 +19,7 @@ jobs:
           cache-dependency-path: "./yarn.lock"
 
       - name: Install dependencies
-        run: yarn install
+        run: yarn install --frozen-lockfile
 
       - name: Build generated libraries
         run: yarn gen


### PR DESCRIPTION
We don't want this updating during CI runs