### PR TITLE
Round lat/lon to 2dp

### DIFF
--- a/app/src/handlers/weather/weather.test.ts
+++ b/app/src/handlers/weather/weather.test.ts
@@ -51,8 +51,8 @@ function mockGeoJsResponse() {
   mockAxios.onGet("https://get.geojs.io/v1/ip/geo.json?ip=1.1.1.1").reply(OK, [
     {
       ip: "1.1.1.1",
-      latitude: "0",
-      longitude: "0",
+      latitude: "0.12345",
+      longitude: "0.98765",
       city: "Sample City",
     },
   ]);
@@ -66,7 +66,7 @@ describe("reverseWeatherHandler", () => {
     requestContext: {
       http: {
         sourceIp: "1.1.1.1",
-        path: "/0/0",
+        path: "/0.12/0.98",
       },
     },
   });
@@ -78,7 +78,7 @@ describe("reverseWeatherHandler", () => {
 
     mockAxios
       .onGet(
-        "https://nominatim.openstreetmap.org/reverse?lat=0&lon=0&format=geocodejson&addressdetails=1&accept-language=en&zoom=15&layer=address",
+        "https://nominatim.openstreetmap.org/reverse?lat=0.12&lon=0.99&format=geocodejson&addressdetails=1&accept-language=en&zoom=15&layer=address",
       )
       .reply(OK, {
         features: [
@@ -96,7 +96,7 @@ describe("reverseWeatherHandler", () => {
   it("returns weather", async () => {
     mockAxios
       .onGet(
-        "https://api.openweathermap.org/data/3.0/onecall?lat=0&lon=0&appid=test-api-key&units=metric",
+        "https://api.openweathermap.org/data/3.0/onecall?lat=0.12&lon=0.99&appid=test-api-key&units=metric",
       )
       .reply(OK, oneCall);
 
@@ -175,7 +175,7 @@ describe("weatherHandler", () => {
             },
             geometry: {
               type: "Point",
-              coordinates: [1, 1],
+              coordinates: [1.123456, 1.987654],
             },
           },
         ],
@@ -185,7 +185,7 @@ describe("weatherHandler", () => {
   it("returns weather", async () => {
     mockAxios
       .onGet(
-        "https://api.openweathermap.org/data/3.0/onecall?lat=1&lon=1&appid=test-api-key&units=metric",
+        "https://api.openweathermap.org/data/3.0/onecall?lat=1.99&lon=1.12&appid=test-api-key&units=metric",
       )
       .reply(OK, oneCall);
 

--- a/app/src/lib/geocode/index.test.ts
+++ b/app/src/lib/geocode/index.test.ts
@@ -42,14 +42,12 @@ describe("toString", () => {
     expect(sampleData.toString()).toEqual("Sample City");
   });
 
-  it("should return lat/lon if no other data", () => {
+  it("should return lat/lon to 2dp if no other data", () => {
     const sampleData = new GeoCodeData({
       latitude: 51.839175049999994,
       longitude: -96.87365529211462,
     });
-    expect(sampleData.toString()).toEqual(
-      "51.839175049999994, -96.87365529211462",
-    );
+    expect(sampleData.toString()).toEqual("51.84, -96.87");
   });
 });
 

--- a/app/src/lib/geocode/index.ts
+++ b/app/src/lib/geocode/index.ts
@@ -19,7 +19,7 @@ interface Coordinate {
   longitude: number;
 }
 
-interface GeoCodeProps extends Coordinate {
+export interface GeoCodeProps extends Coordinate {
   city?: string;
   country?: string;
   country_code?: string;
@@ -33,8 +33,8 @@ interface GeoCodeProps extends Coordinate {
 
 export class GeoCodeData implements GeoCodeProps {
   // TODO: Can we avoid repeating these properties of the above interface?
-  public readonly latitude!: number;
-  public readonly longitude!: number;
+  private readonly _latitude!: number;
+  private readonly _longitude!: number;
   public readonly city?: string;
   public readonly country?: string;
   public readonly country_code?: string;
@@ -46,7 +46,14 @@ export class GeoCodeData implements GeoCodeProps {
   public readonly type?: string;
 
   constructor(props: GeoCodeProps) {
-    Object.assign(this, props);
+    // Rename latitude and longitude to _latitude and _longitude to avoid
+    // conflict with the getters.
+    const { latitude, longitude, ...rest } = props;
+    Object.assign(this, {
+      _latitude: latitude,
+      _longitude: longitude,
+      ...rest,
+    });
   }
 
   public toString(): string {
@@ -63,6 +70,14 @@ export class GeoCodeData implements GeoCodeProps {
     }
 
     return parts.join(", ");
+  }
+
+  public get latitude(): number {
+    return parseFloat(this._latitude.toFixed(2));
+  }
+
+  public get longitude(): number {
+    return parseFloat(this._longitude.toFixed(2));
   }
 }
 
@@ -115,7 +130,7 @@ async function getCache({
 
 async function setCache(
   { key, acceptLanguage }: cacheKey,
-  geoCodeData: GeoCodeData,
+  geoCodeData: GeoCodeProps,
 ): Promise<PutCommandOutput> {
   const ttl = Math.floor(Date.now() / 1000) + 24 * 60 * 60; // 24 hours TTL
 

--- a/app/src/lib/geocode/middleware.test.ts
+++ b/app/src/lib/geocode/middleware.test.ts
@@ -61,8 +61,8 @@ describe("Reverse GeoCode Middleware", () => {
     geoLocate: {
       ip: "1.1.1.1",
       location: {
-        latitude: 1,
-        longitude: 1,
+        latitude: 1.23456,
+        longitude: 9.87654,
       },
     },
   });
@@ -76,7 +76,7 @@ describe("Reverse GeoCode Middleware", () => {
 
     mockAxios
       .onGet(
-        "https://nominatim.openstreetmap.org/reverse?lat=1&lon=1&format=geocodejson&addressdetails=1&accept-language=en&zoom=15&layer=address",
+        "https://nominatim.openstreetmap.org/reverse?lat=1.23&lon=9.88&format=geocodejson&addressdetails=1&accept-language=en&zoom=15&layer=address",
       )
       .reply(OK, {
         features: [
@@ -92,13 +92,9 @@ describe("Reverse GeoCode Middleware", () => {
 
     const result = await middyHandler(mockEvent, geoLocateContext);
 
-    expect(result).toEqual(
-      expect.objectContaining({
-        city: "Sample City",
-        latitude: 1,
-        longitude: 1,
-      }),
-    );
+    expect(result.city).toEqual("Sample City");
+    expect(result.latitude).toEqual(1.23);
+    expect(result.longitude).toEqual(9.88);
   });
 
   it("returns the lat/lon if the address can't be found", async () => {
@@ -110,10 +106,13 @@ describe("Reverse GeoCode Middleware", () => {
 
     const result = await middyHandler(mockEvent, geoLocateContext);
 
-    expect(result).toEqual({
-      latitude: 1,
-      longitude: 1,
-    });
+    expect(result).toEqual(
+      // These get rounded inside `GeoCodeData`
+      new GeoCodeData({
+        latitude: 1.23456,
+        longitude: 9.87654,
+      }),
+    );
   });
 
   it("returns the lat/lon if the request fails", async () => {
@@ -123,10 +122,8 @@ describe("Reverse GeoCode Middleware", () => {
 
     const result = await middyHandler(mockEvent, geoLocateContext);
 
-    expect(result).toEqual({
-      latitude: 1,
-      longitude: 1,
-    });
+    expect(result.latitude).toEqual(1.23);
+    expect(result.longitude).toEqual(9.88);
   });
 });
 

--- a/app/src/lib/geocode/middleware.ts
+++ b/app/src/lib/geocode/middleware.ts
@@ -40,11 +40,15 @@ export function reverseGeoCodeMiddleware<TResult>(): MiddlewareObj<
       const acceptLanguage = event.headers["accept-language"] ?? "en";
       const { latitude, longitude } = context.geoLocate.location;
 
+      // Round lat/lon to 2 decimal places
+      const lat = parseFloat(latitude.toFixed(2));
+      const lon = parseFloat(longitude.toFixed(2));
+
       try {
         const loc = await reverseGeocode(
           {
-            latitude,
-            longitude,
+            latitude: lat,
+            longitude: lon,
             acceptLanguage,
           },
           logger,
@@ -59,7 +63,7 @@ export function reverseGeoCodeMiddleware<TResult>(): MiddlewareObj<
             latitude,
             longitude,
           });
-          context.geoCode = { latitude, longitude };
+          context.geoCode = new GeoCodeData({ latitude, longitude });
           return;
         }
 

--- a/app/src/lib/handler-factory/index.test.ts
+++ b/app/src/lib/handler-factory/index.test.ts
@@ -36,8 +36,8 @@ mockAxios
   .reply(OK, [
     {
       ip: "1.1.1.1",
-      latitude: "51.1",
-      longitude: "-96.1",
+      latitude: "51.12345",
+      longitude: "-96.98765",
     },
   ]);
 
@@ -67,7 +67,7 @@ mockAxios
         },
         geometry: {
           type: "Point",
-          coordinates: [37, 13],
+          coordinates: [313.368, 13.369],
         },
       },
     ],
@@ -246,8 +246,8 @@ describe("handler factory", () => {
     expect(result).toMatchObject({
       body: {
         name: "My Cool City",
-        latitude: 13,
-        longitude: 37,
+        latitude: 13.37,
+        longitude: 313.37,
       },
     });
   });

--- a/app/src/lib/metno/client.test.ts
+++ b/app/src/lib/metno/client.test.ts
@@ -1,14 +1,29 @@
 import { describe, expect, it } from "@jest/globals";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+import { StatusCodes } from "http-status-codes";
 
 import { GeoCodeData } from "@/lib/geocode";
 import { Logger } from "@/lib/logger";
 
 import { getRawWeather } from ".";
 
-const greenwich: GeoCodeData = {
+const { OK } = StatusCodes;
+
+const mockAxios = new AxiosMockAdapter(axios);
+
+const greenwich = new GeoCodeData({
   latitude: 51.477,
   longitude: 0,
-};
+});
+
+import greenwichResp from "./testdata/greenwich.json";
+
+mockAxios
+  .onGet(
+    "https://api.met.no/weatherapi/locationforecast/2.0/complete?lat=51.48&lon=0",
+  )
+  .reply(OK, greenwichResp);
 
 describe("met.no client", () => {
   it("should return weather", async () => {

--- a/app/src/lib/metno/client.ts
+++ b/app/src/lib/metno/client.ts
@@ -1,5 +1,5 @@
 import { retryableAxios } from "@/lib/axios";
-import { GeoCodeData } from "@/lib/geocode";
+import { GeoCodeData, GeoCodeProps } from "@/lib/geocode";
 import { Logger } from "@/lib/logger";
 import {
   Configuration,
@@ -13,14 +13,14 @@ export async function getRawWeather(
 ): Promise<METJSONForecast> {
   const metno = DataApiFactory(
     new Configuration({
-      basePath: "http://api.met.no/weatherapi/locationforecast/2.0",
+      basePath: "https://api.met.no/weatherapi/locationforecast/2.0",
     }),
     undefined,
     retryableAxios(logger),
   );
 
   // Round lat/lon to 2 decimal places
-  const roundedLocation: GeoCodeData = {
+  const roundedLocation: GeoCodeProps = {
     latitude: parseFloat(location.latitude.toFixed(2)),
     longitude: parseFloat(location.longitude.toFixed(2)),
   };

--- a/app/src/lib/metno/testdata/greenwich.json
+++ b/app/src/lib/metno/testdata/greenwich.json
@@ -1,0 +1,3090 @@
+{
+  "type": "Feature",
+  "geometry": { "type": "Point", "coordinates": [0, 51.477, 0] },
+  "properties": {
+    "meta": {
+      "updated_at": "2024-03-10T23:27:31Z",
+      "units": {
+        "air_pressure_at_sea_level": "hPa",
+        "air_temperature": "celsius",
+        "air_temperature_max": "celsius",
+        "air_temperature_min": "celsius",
+        "cloud_area_fraction": "%",
+        "cloud_area_fraction_high": "%",
+        "cloud_area_fraction_low": "%",
+        "cloud_area_fraction_medium": "%",
+        "dew_point_temperature": "celsius",
+        "fog_area_fraction": "%",
+        "precipitation_amount": "mm",
+        "relative_humidity": "%",
+        "ultraviolet_index_clear_sky": "1",
+        "wind_from_direction": "degrees",
+        "wind_speed": "m/s"
+      }
+    },
+    "timeseries": [
+      {
+        "time": "2024-03-10T23:00:00Z",
+        "data": {
+          "instant": {
+            "details": {
+              "air_pressure_at_sea_level": 999.1,
+              "air_temperature": 7.0,
+              "cloud_area_fraction": 100.0,
+              "cloud_area_fraction_high": 100.0,
+              "cloud_area_fraction_low": 100.0,
+              "cloud_area_fraction_medium": 100.0,
+              "dew_point_temperature": 6.4,
+              "fog_area_fraction": 0.0,
+              "relative_humidity": 95.9,
+              "ultraviolet_index_clear_sky": 0.0,
+              "wind_from_direction": 26.5,
+              "wind_speed": 2.0
+            }
+          },
+          "next_12_hours": {
+            "summary": { "symbol_code": "lightrain" },
+            "details": {}
+          },
+          "next_1_hours": {
+            "summary": { "symbol_code": "rain" },
+            "details": { "precipitation_amount": 0.3 }
+          },
+          "next_6_hours": {
+            "summary": { "symbol_code": "rain" },
+            "details": {
+              "air_temperature_max": 6.9,
+              "air_temperature_min": 6.5,
+              "precipitation_amount": 3.0
+            }
+          }
+        }
+      },
+      {
+        "time": "2024-03-11T00:00:00Z",
+        "data": {
+          "instant": {
+            "details": {
+              "air_pressure_at_sea_level": 999.1,
+              "air_temperature": 6.9,
+              "cloud_area_fraction": 100.0,
+              "cloud_area_fraction_high": 100.0,
+              "cloud_area_fraction_low": 100.0,
+              "cloud_area_fraction_medium": 100.0,
+              "dew_point_temperature": 6.3,
+              "fog_area_fraction": 0.0,
+              "relative_humidity": 96.0,
+              "ultraviolet_index_clear_sky": 0.0,
+              "wind_from_direction": 359.5,
+              "wind_speed": 2.2
+            }
+          },
+          "next_12_hours": {
+            "summary": { "symbol_code": "lightrain" },
+            "details": {}
+          },
+          "next_1_hours": {
+            "summary": { "symbol_code": "rain" },
+            "details": { "precipitation_amount": 0.5 }
+          },
+          "next_6_hours": {
+            "summary": { "symbol_code": "rain" },
+            "details": {
+              "air_temperature_max": 6.7,
+              "air_temperature_min": 6.5,
+              "precipitation_amount": 2.7
+            }
+          }
+        }
+      },
+      {
+        "time": "2024-03-11T01:00:00Z",
+        "data": {
+          "instant": {
+            "details": {
+              "air_pressure_at_sea_level": 999.7,
+              "air_temperature": 6.6,
+              "cloud_area_fraction": 100.0,
+              "cloud_area_fraction_high": 100.0,
+              "cloud_area_fraction_low": 100.0,
+              "cloud_area_fraction_medium": 100.0,
+              "dew_point_temperature": 6.1,
+              "fog_area_fraction": 0.0,
+              "relative_humidity": 96.5,
+              "ultraviolet_index_clear_sky": 0.0,
+              "wind_from_direction": 5.2,
+              "wind_speed": 2.1
+            }
+          },
+          "next_12_hours": {
+            "summary": { "symbol_code": "lightrain" },
+            "details": {}
+          },
+          "next_1_hours": {
+            "summary": { "symbol_code": "heavyrain" },
+            "details": { "precipitation_amount": 1.1 }
+          },
+          "next_6_hours": {
+            "summary": { "symbol_code": "rain" },
+            "details": {
+              "air_temperature_max": 7.0,
+              "air_temperature_min": 6.5,
+              "precipitation_amount": 2.2
+            }
+          }
+        }
+      },
+      {
+        "time": "2024-03-11T02:00:00Z",
+        "data": {
+          "instant": {
+            "details": {
+              "air_pressure_at_sea_level": 1000.1,
+              "air_temperature": 6.6,
+              "cloud_area_fraction": 100.0,
+              "cloud_area_fraction_high": 94.5,
+              "cloud_area_fraction_low": 100.0,
+              "cloud_area_fraction_medium": 100.0,
+              "dew_point_temperature": 6.1,
+              "fog_area_fraction": 0.0,
+              "relative_humidity": 96.7,
+              "ultraviolet_index_clear_sky": 0.0,
+              "wind_from_direction": 333.1,
+              "wind_speed": 2.0
+            }
+          },
+          "next_12_hours": {
+            "summary": { "symbol_code": "lightrain" },
+            "details": {}
+          },
+          "next_1_hours": {
+            "summary": { "symbol_code": "rain" },
+            "details": { "precipitation_amount": 0.8 }
+          },
+          "next_6_hours": {
+            "summary": { "symbol_code": "rain" },
+            "details": {
+              "air_temperature_max": 7.3,
+              "air_temperature_min": 6.5,
+              "precipitation_amount": 1.2
+            }
+          }
+        }
+      },
+      {
+        "time": "2024-03-11T03:00:00Z",
+        "data": {
+          "instant": {
+            "details": {
+              "air_pressure_at_sea_level": 1000.3,
+              "air_temperature": 6.5,
+              "cloud_area_fraction": 100.0,
+              "cloud_area_fraction_high": 100.0,
+              "cloud_area_fraction_low": 60.9,
+              "cloud_area_fraction_medium": 100.0,
+              "dew_point_temperature": 6.1,
+              "fog_area_fraction": 0.0,
+              "relative_humidity": 96.8,
+              "ultraviolet_index_clear_sky": 0.0,
+              "wind_from_direction": 326.1,
+              "wind_speed": 2.5
+            }
+          },
+          "next_12_hours": {
+            "summary": { "symbol_code": "cloudy" },
+            "details": {}
+          },
+          "next_1_hours": {
+            "summary": { "symbol_code": "rain" },
+            "details": { "precipitation_amount": 0.3 }
+          },
+          "next_6_hours": {
+            "summary": { "symbol_code": "cloudy" },
+            "details": {
+              "air_temperature_max": 8.0,
+              "air_temperature_min": 6.6,
+              "precipitation_amount": 0.4
+            }
+          }
+        }
+      },
+      {
+        "time": "2024-03-11T04:00:00Z",
+        "data": {
+          "instant": {
+            "details": {
+              "air_pressure_at_sea_level": 1000.6,
+              "air_temperature": 6.6,
+              "cloud_area_fraction": 100.0,
+              "cloud_area_fraction_high": 100.0,
+              "cloud_area_fraction_low": 86.7,
+              "cloud_area_fraction_medium": 100.0,
+              "dew_point_temperature": 6.1,
+              "fog_area_fraction": 0.0,
+              "relative_humidity": 96.3,
+              "ultraviolet_index_clear_sky": 0.0,
+              "wind_from_direction": 311.5,
+              "wind_speed": 2.3
+            }
+          },
+          "next_12_hours": {
+            "summary": { "symbol_code": "cloudy" },
+            "details": {}
+          },
+          "next_1_hours": {
+            "summary": { "symbol_code": "cloudy" },
+            "details": { "precipitation_amount": 0.0 }
+          },
+          "next_6_hours": {
+            "summary": { "symbol_code": "cloudy" },
+            "details": {
+              "air_temperature_max": 8.5,
+              "air_temperature_min": 6.7,
+              "precipitation_amount": 0.1
+            }
+          }
+        }
+      },
+      {
+        "time": "2024-03-11T05:00:00Z",
+        "data": {
+          "instant": {
+            "details": {
+              "air_pressure_at_sea_level": 1001.1,
+              "air_temperature": 6.7,
+              "cloud_area_fraction": 100.0,
+              "cloud_area_fraction_high": 99.2,
+              "cloud_area_fraction_low": 100.0,
+              "cloud_area_fraction_medium": 93.7,
+              "dew_point_temperature": 6.1,
+              "fog_area_fraction": 0.0,
+              "relative_humidity": 96.1,
+              "ultraviolet_index_clear_sky": 0.0,
+              "wind_from_direction": 305.1,
+              "wind_speed": 2.7
+            }
+          },
+          "next_12_hours": {
+            "summary": { "symbol_code": "cloudy" },
+            "details": {}
+          },
+          "next_1_hours": {
+            "summary": { "symbol_code": "cloudy" },
+            "details": { "precipitation_amount": 0.0 }
+          },
+          "next_6_hours": {
+            "summary": { "symbol_code": "cloudy" },
+            "details": {
+              "air_temperature_max": 9.3,
+              "air_temperature_min": 6.7,
+              "precipitation_amount": 0.1
+            }
+          }
+        }
+      },
+      {
+        "time": "2024-03-11T06:00:00Z",
+        "data": {
+          "instant": {
+            "details": {
+              "air_pressure_at_sea_level": 1001.6,
+              "air_temperature": 6.7,
+              "cloud_area_fraction": 100.0,
+              "cloud_area_fraction_high": 58.6,
+              "cloud_area_fraction_low": 100.0,
+              "cloud_area_fraction_medium": 73.4,
+              "dew_point_temperature": 6.2,
+              "fog_area_fraction": 0.0,
+              "relative_humidity": 95.8,
+              "ultraviolet_index_clear_sky": 0.0,
+              "wind_from_direction": 302.4,
+              "wind_speed": 2.8
+            }
+          },
+          "next_12_hours": {
+            "summary": { "symbol_code": "cloudy" },
+            "details": {}
+          },
+          "next_1_hours": {
+            "summary": { "symbol_code": "cloudy" },
+            "details": { "precipitation_amount": 0.0 }
+          },
+          "next_6_hours": {
+            "summary": { "symbol_code": "cloudy" },
+            "details": {
+              "air_temperature_max": 10.0,
+              "air_temperature_min": 7.0,
+              "precipitation_amount": 0.2
+            }
+          }
+        }
+      },
+      {
+        "time": "2024-03-11T07:00:00Z",
+        "data": {
+          "instant": {
+            "details": {
+              "air_pressure_at_sea_level": 1002.2,
+              "air_temperature": 7.0,
+              "cloud_area_fraction": 100.0,
+              "cloud_area_fraction_high": 0.0,
+              "cloud_area_fraction_low": 100.0,
+              "cloud_area_fraction_medium": 82.8,
+              "dew_point_temperature": 6.3,
+              "fog_area_fraction": 0.0,
+              "relative_humidity": 95.4,
+              "ultraviolet_index_clear_sky": 0.1,
+              "wind_from_direction": 312.3,
+              "wind_speed": 3.4
+            }
+          },
+          "next_12_hours": {
+            "summary": { "symbol_code": "cloudy" },
+            "details": {}
+          },
+          "next_1_hours": {
+            "summary": { "symbol_code": "cloudy" },
+            "details": { "precipitation_amount": 0.0 }
+          },
+          "next_6_hours": {
+            "summary": { "symbol_code": "cloudy" },
+            "details": {
+              "air_temperature_max": 10.6,
+              "air_temperature_min": 7.3,
+              "precipitation_amount": 0.2
+            }
+          }
+        }
+      },
+      {
+        "time": "2024-03-11T08:00:00Z",
+        "data": {
+          "instant": {
+            "details": {
+              "air_pressure_at_sea_level": 1003.0,
+              "air_temperature": 7.3,
+              "cloud_area_fraction": 100.0,
+              "cloud_area_fraction_high": 0.0,
+              "cloud_area_fraction_low": 100.0,
+              "cloud_area_fraction_medium": 0.8,
+              "dew_point_temperature": 6.5,
+              "fog_area_fraction": 0.0,
+              "relative_humidity": 94.3,
+              "ultraviolet_index_clear_sky": 0.4,
+              "wind_from_direction": 336.9,
+              "wind_speed": 4.1
+            }
+          },
+          "next_12_hours": {
+            "summary": { "symbol_code": "cloudy" },
+            "details": {}
+          },
+          "next_1_hours": {
+            "summary": { "symbol_code": "cloudy" },
+            "details": { "precipitation_amount": 0.0 }
+          },
+          "next_6_hours": {
+            "summary": { "symbol_code": "cloudy" },
+            "details": {
+              "air_temperature_max": 10.6,
+              "air_temperature_min": 8.0,
+              "precipitation_amount": 0.2
+            }
+          }
+        }
+      },
+      {
+        "time": "2024-03-11T09:00:00Z",
+        "data": {
+          "instant": {
+            "details": {
+              "air_pressure_at_sea_level": 1003.8,
+              "air_temperature": 8.0,
+              "cloud_area_fraction": 100.0,
+              "cloud_area_fraction_high": 11.7,
+              "cloud_area_fraction_low": 100.0,
+              "cloud_area_fraction_medium": 0.0,
+              "dew_point_temperature": 6.5,
+              "fog_area_fraction": 0.0,
+              "relative_humidity": 90.2,
+              "ultraviolet_index_clear_sky": 0.9,
+              "wind_from_direction": 358.8,
+              "wind_speed": 4.7
+            }
+          },
+          "next_12_hours": {
+            "summary": { "symbol_code": "cloudy" },
+            "details": {}
+          },
+          "next_1_hours": {
+            "summary": { "symbol_code": "cloudy" },
+            "details": { "precipitation_amount": 0.0 }
+          },
+          "next_6_hours": {
+            "summary": { "symbol_code": "cloudy" },
+            "details": {
+              "air_temperature_max": 10.6,
+              "air_temperature_min": 8.5,
+              "precipitation_amount": 0.2
+            }
+          }
+        }
+      },
+      {
+        "time": "2024-03-11T10:00:00Z",
+        "data": {
+          "instant": {
+            "details": {
+              "air_pressure_at_sea_level": 1004.7,
+              "air_temperature": 8.5,
+              "cloud_area_fraction": 100.0,
+              "cloud_area_fraction_high": 0.0,
+              "cloud_area_fraction_low": 100.0,
+              "cloud_area_fraction_medium": 9.4,
+              "dew_point_temperature": 6.6,
+              "fog_area_fraction": 0.0,
+              "relative_humidity": 88.0,
+              "ultraviolet_index_clear_sky": 1.4,
+              "wind_from_direction": 349.9,
+              "wind_speed": 4.8
+            }
+          },
+          "next_12_hours": {
+            "summary": { "symbol_code": "cloudy" },
+            "details": {}
+          },
+          "next_1_hours": {
+            "summary": { "symbol_code": "cloudy" },
+            "details": { "precipitation_amount": 0.0 }
+          },
+          "next_6_hours": {
+            "summary": { "symbol_code": "cloudy" },
+            "details": {
+              "air_temperature_max": 10.6,
+              "air_temperature_min": 9.3,
+              "precipitation_amount": 0.2
+            }
+          }
+        }
+      },
+      {
+        "time": "2024-03-11T11:00:00Z",
+        "data": {
+          "instant": {
+            "details": {
+              "air_pressure_at_sea_level": 1005.2,
+              "air_temperature": 9.3,
+              "cloud_area_fraction": 100.0,
+              "cloud_area_fraction_high": 10.2,
+              "cloud_area_fraction_low": 100.0,
+              "cloud_area_fraction_medium": 0.0,
+              "dew_point_temperature": 6.6,
+              "fog_area_fraction": 0.0,
+              "relative_humidity": 83.8,
+              "ultraviolet_index_clear_sky": 1.8,
+              "wind_from_direction": 350.0,
+              "wind_speed": 5.2
+            }
+          },
+          "next_12_hours": {
+            "summary": { "symbol_code": "cloudy" },
+            "details": {}
+          },
+          "next_1_hours": {
+            "summary": { "symbol_code": "cloudy" },
+            "details": { "precipitation_amount": 0.0 }
+          },
+          "next_6_hours": {
+            "summary": { "symbol_code": "cloudy" },
+            "details": {
+              "air_temperature_max": 10.6,
+              "air_temperature_min": 10.0,
+              "precipitation_amount": 0.2
+            }
+          }
+        }
+      },
+      {
+        "time": "2024-03-11T12:00:00Z",
+        "data": {
+          "instant": {
+            "details": {
+              "air_pressure_at_sea_level": 1005.6,
+              "air_temperature": 10.0,
+              "cloud_area_fraction": 100.0,
+              "cloud_area_fraction_high": 0.0,
+              "cloud_area_fraction_low": 100.0,
+              "cloud_area_fraction_medium": 0.0,
+              "dew_point_temperature": 6.5,
+              "fog_area_fraction": 0.0,
+              "relative_humidity": 79.7,
+              "ultraviolet_index_clear_sky": 2.0,
+              "wind_from_direction": 344.8,
+              "wind_speed": 5.3
+            }
+          },
+          "next_12_hours": {
+            "summary": { "symbol_code": "cloudy" },
+            "details": {}
+          },
+          "next_1_hours": {
+            "summary": { "symbol_code": "cloudy" },
+            "details": { "precipitation_amount": 0.0 }
+          },
+          "next_6_hours": {
+            "summary": { "symbol_code": "cloudy" },
+            "details": {
+              "air_temperature_max": 10.6,
+              "air_temperature_min": 9.3,
+              "precipitation_amount": 0.2
+            }
+          }
+        }
+      },
+      {
+        "time": "2024-03-11T13:00:00Z",
+        "data": {
+          "instant": {
+            "details": {
+              "air_pressure_at_sea_level": 1006.4,
+              "air_temperature": 10.6,
+              "cloud_area_fraction": 100.0,
+              "cloud_area_fraction_high": 0.0,
+              "cloud_area_fraction_low": 100.0,
+              "cloud_area_fraction_medium": 0.0,
+              "dew_point_temperature": 6.2,
+              "fog_area_fraction": 0.0,
+              "relative_humidity": 74.8,
+              "ultraviolet_index_clear_sky": 1.8,
+              "wind_from_direction": 341.8,
+              "wind_speed": 5.2
+            }
+          },
+          "next_12_hours": {
+            "summary": { "symbol_code": "cloudy" },
+            "details": {}
+          },
+          "next_1_hours": {
+            "summary": { "symbol_code": "cloudy" },
+            "details": { "precipitation_amount": 0.0 }
+          },
+          "next_6_hours": {
+            "summary": { "symbol_code": "cloudy" },
+            "details": {
+              "air_temperature_max": 10.5,
+              "air_temperature_min": 8.9,
+              "precipitation_amount": 0.2
+            }
+          }
+        }
+      },
+      {
+        "time": "2024-03-11T14:00:00Z",
+        "data": {
+          "instant": {
+            "details": {
+              "air_pressure_at_sea_level": 1006.9,
+              "air_temperature": 10.4,
+              "cloud_area_fraction": 100.0,
+              "cloud_area_fraction_high": 0.0,
+              "cloud_area_fraction_low": 100.0,
+              "cloud_area_fraction_medium": 0.0,
+              "dew_point_temperature": 5.9,
+              "fog_area_fraction": 0.0,
+              "relative_humidity": 74.3,
+              "ultraviolet_index_clear_sky": 1.4,
+              "wind_from_direction": 339.4,
+              "wind_speed": 5.0
+            }
+          },
+          "next_12_hours": {
+            "summary": { "symbol_code": "cloudy" },
+            "details": {}
+          },
+          "next_1_hours": {
+            "summary": { "symbol_code": "cloudy" },
+            "details": { "precipitation_amount": 0.0 }
+          },
+          "next_6_hours": {
+            "summary": { "symbol_code": "cloudy" },
+            "details": {
+              "air_temperature_max": 10.5,
+              "air_temperature_min": 8.5,
+              "precipitation_amount": 0.2
+            }
+          }
+        }
+      },
+      {
+        "time": "2024-03-11T15:00:00Z",
+        "data": {
+          "instant": {
+            "details": {
+              "air_pressure_at_sea_level": 1007.3,
+              "air_temperature": 10.4,
+              "cloud_area_fraction": 100.0,
+              "cloud_area_fraction_high": 0.0,
+              "cloud_area_fraction_low": 100.0,
+              "cloud_area_fraction_medium": 0.0,
+              "dew_point_temperature": 5.5,
+              "fog_area_fraction": 0.0,
+              "relative_humidity": 71.7,
+              "ultraviolet_index_clear_sky": 0.8,
+              "wind_from_direction": 336.8,
+              "wind_speed": 4.8
+            }
+          },
+          "next_12_hours": {
+            "summary": { "symbol_code": "cloudy" },
+            "details": {}
+          },
+          "next_1_hours": {
+            "summary": { "symbol_code": "cloudy" },
+            "details": { "precipitation_amount": 0.0 }
+          },
+          "next_6_hours": {
+            "summary": { "symbol_code": "cloudy" },
+            "details": {
+              "air_temperature_max": 10.5,
+              "air_temperature_min": 7.8,
+              "precipitation_amount": 0.1
+            }
+          }
+        }
+      },
+      {
+        "time": "2024-03-11T16:00:00Z",
+        "data": {
+          "instant": {
+            "details": {
+              "air_pressure_at_sea_level": 1007.7,
+              "air_temperature": 10.5,
+              "cloud_area_fraction": 67.2,
+              "cloud_area_fraction_high": 5.5,
+              "cloud_area_fraction_low": 65.6,
+              "cloud_area_fraction_medium": 0.0,
+              "dew_point_temperature": 5.0,
+              "fog_area_fraction": 0.0,
+              "relative_humidity": 68.8,
+              "ultraviolet_index_clear_sky": 0.4,
+              "wind_from_direction": 343.9,
+              "wind_speed": 4.5
+            }
+          },
+          "next_12_hours": {
+            "summary": { "symbol_code": "cloudy" },
+            "details": {}
+          },
+          "next_1_hours": {
+            "summary": { "symbol_code": "partlycloudy_day" },
+            "details": { "precipitation_amount": 0.0 }
+          },
+          "next_6_hours": {
+            "summary": { "symbol_code": "cloudy" },
+            "details": {
+              "air_temperature_max": 10.0,
+              "air_temperature_min": 7.8,
+              "precipitation_amount": 0.1
+            }
+          }
+        }
+      },
+      {
+        "time": "2024-03-11T17:00:00Z",
+        "data": {
+          "instant": {
+            "details": {
+              "air_pressure_at_sea_level": 1008.8,
+              "air_temperature": 10.0,
+              "cloud_area_fraction": 100.0,
+              "cloud_area_fraction_high": 79.7,
+              "cloud_area_fraction_low": 100.0,
+              "cloud_area_fraction_medium": 0.0,
+              "dew_point_temperature": 5.2,
+              "fog_area_fraction": 0.0,
+              "relative_humidity": 72.3,
+              "ultraviolet_index_clear_sky": 0.1,
+              "wind_from_direction": 330.6,
+              "wind_speed": 3.5
+            }
+          },
+          "next_12_hours": {
+            "summary": { "symbol_code": "cloudy" },
+            "details": {}
+          },
+          "next_1_hours": {
+            "summary": { "symbol_code": "cloudy" },
+            "details": { "precipitation_amount": 0.0 }
+          },
+          "next_6_hours": {
+            "summary": { "symbol_code": "cloudy" },
+            "details": {
+              "air_temperature_max": 9.3,
+              "air_temperature_min": 7.7,
+              "precipitation_amount": 0.1
+            }
+          }
+        }
+      },
+      {
+        "time": "2024-03-11T18:00:00Z",
+        "data": {
+          "instant": {
+            "details": {
+              "air_pressure_at_sea_level": 1009.6,
+              "air_temperature": 9.3,
+              "cloud_area_fraction": 100.0,
+              "cloud_area_fraction_high": 91.4,
+              "cloud_area_fraction_low": 100.0,
+              "cloud_area_fraction_medium": 0.0,
+              "dew_point_temperature": 5.2,
+              "fog_area_fraction": 0.0,
+              "relative_humidity": 75.7,
+              "ultraviolet_index_clear_sky": 0.0,
+              "wind_from_direction": 327.0,
+              "wind_speed": 3.1
+            }
+          },
+          "next_12_hours": {
+            "summary": { "symbol_code": "cloudy" },
+            "details": {}
+          },
+          "next_1_hours": {
+            "summary": { "symbol_code": "cloudy" },
+            "details": { "precipitation_amount": 0.0 }
+          },
+          "next_6_hours": {
+            "summary": { "symbol_code": "cloudy" },
+            "details": {
+              "air_temperature_max": 8.9,
+              "air_temperature_min": 7.5,
+              "precipitation_amount": 0.1
+            }
+          }
+        }
+      },
+      {
+        "time": "2024-03-11T19:00:00Z",
+        "data": {
+          "instant": {
+            "details": {
+              "air_pressure_at_sea_level": 1010.2,
+              "air_temperature": 8.9,
+              "cloud_area_fraction": 100.0,
+              "cloud_area_fraction_high": 99.2,
+              "cloud_area_fraction_low": 97.7,
+              "cloud_area_fraction_medium": 0.0,
+              "dew_point_temperature": 5.4,
+              "fog_area_fraction": 0.0,
+              "relative_humidity": 78.6,
+              "ultraviolet_index_clear_sky": 0.0,
+              "wind_from_direction": 322.5,
+              "wind_speed": 3.0
+            }
+          },
+          "next_12_hours": {
+            "summary": { "symbol_code": "cloudy" },
+            "details": {}
+          },
+          "next_1_hours": {
+            "summary": { "symbol_code": "cloudy" },
+            "details": { "precipitation_amount": 0.0 }
+          },
+          "next_6_hours": {
+            "summary": { "symbol_code": "cloudy" },
+            "details": {
+              "air_temperature_max": 8.5,
+              "air_temperature_min": 7.0,
+              "precipitation_amount": 0.0
+            }
+          }
+        }
+      },
+      {
+        "time": "2024-03-11T20:00:00Z",
+        "data": {
+          "instant": {
+            "details": {
+              "air_pressure_at_sea_level": 1010.6,
+              "air_temperature": 8.5,
+              "cloud_area_fraction": 100.0,
+              "cloud_area_fraction_high": 100.0,
+              "cloud_area_fraction_low": 100.0,
+              "cloud_area_fraction_medium": 0.0,
+              "dew_point_temperature": 5.5,
+              "fog_area_fraction": 0.0,
+              "relative_humidity": 81.1,
+              "ultraviolet_index_clear_sky": 0.0,
+              "wind_from_direction": 307.8,
+              "wind_speed": 2.7
+            }
+          },
+          "next_12_hours": {
+            "summary": { "symbol_code": "lightrain" },
+            "details": {}
+          },
+          "next_1_hours": {
+            "summary": { "symbol_code": "cloudy" },
+            "details": { "precipitation_amount": 0.0 }
+          },
+          "next_6_hours": {
+            "summary": { "symbol_code": "cloudy" },
+            "details": {
+              "air_temperature_max": 7.9,
+              "air_temperature_min": 6.7,
+              "precipitation_amount": 0.0
+            }
+          }
+        }
+      },
+      {
+        "time": "2024-03-11T21:00:00Z",
+        "data": {
+          "instant": {
+            "details": {
+              "air_pressure_at_sea_level": 1011.2,
+              "air_temperature": 7.8,
+              "cloud_area_fraction": 100.0,
+              "cloud_area_fraction_high": 95.3,
+              "cloud_area_fraction_low": 100.0,
+              "cloud_area_fraction_medium": 0.0,
+              "dew_point_temperature": 5.4,
+              "fog_area_fraction": 0.0,
+              "relative_humidity": 83.8,
+              "ultraviolet_index_clear_sky": 0.0,
+              "wind_from_direction": 296.2,
+              "wind_speed": 2.7
+            }
+          },
+          "next_12_hours": {
+            "summary": { "symbol_code": "lightrain" },
+            "details": {}
+          },
+          "next_1_hours": {
+            "summary": { "symbol_code": "cloudy" },
+            "details": { "precipitation_amount": 0.0 }
+          },
+          "next_6_hours": {
+            "summary": { "symbol_code": "cloudy" },
+            "details": {
+              "air_temperature_max": 7.9,
+              "air_temperature_min": 6.7,
+              "precipitation_amount": 0.0
+            }
+          }
+        }
+      },
+      {
+        "time": "2024-03-11T22:00:00Z",
+        "data": {
+          "instant": {
+            "details": {
+              "air_pressure_at_sea_level": 1011.7,
+              "air_temperature": 7.9,
+              "cloud_area_fraction": 100.0,
+              "cloud_area_fraction_high": 100.0,
+              "cloud_area_fraction_low": 100.0,
+              "cloud_area_fraction_medium": 0.0,
+              "dew_point_temperature": 5.3,
+              "fog_area_fraction": 0.0,
+              "relative_humidity": 82.4,
+              "ultraviolet_index_clear_sky": 0.0,
+              "wind_from_direction": 284.5,
+              "wind_speed": 2.9
+            }
+          },
+          "next_12_hours": {
+            "summary": { "symbol_code": "lightrain" },
+            "details": {}
+          },
+          "next_1_hours": {
+            "summary": { "symbol_code": "cloudy" },
+            "details": { "precipitation_amount": 0.0 }
+          },
+          "next_6_hours": {
+            "summary": { "symbol_code": "cloudy" },
+            "details": {
+              "air_temperature_max": 7.7,
+              "air_temperature_min": 6.5,
+              "precipitation_amount": 0.0
+            }
+          }
+        }
+      },
+      {
+        "time": "2024-03-11T23:00:00Z",
+        "data": {
+          "instant": {
+            "details": {
+              "air_pressure_at_sea_level": 1011.9,
+              "air_temperature": 7.7,
+              "cloud_area_fraction": 100.0,
+              "cloud_area_fraction_high": 100.0,
+              "cloud_area_fraction_low": 93.0,
+              "cloud_area_fraction_medium": 0.0,
+              "dew_point_temperature": 5.1,
+              "fog_area_fraction": 0.0,
+              "relative_humidity": 82.7,
+              "ultraviolet_index_clear_sky": 0.0,
+              "wind_from_direction": 278.4,
+              "wind_speed": 2.8
+            }
+          },
+          "next_12_hours": {
+            "summary": { "symbol_code": "lightrain" },
+            "details": {}
+          },
+          "next_1_hours": {
+            "summary": { "symbol_code": "cloudy" },
+            "details": { "precipitation_amount": 0.0 }
+          },
+          "next_6_hours": {
+            "summary": { "symbol_code": "cloudy" },
+            "details": {
+              "air_temperature_max": 7.5,
+              "air_temperature_min": 6.1,
+              "precipitation_amount": 0.0
+            }
+          }
+        }
+      },
+      {
+        "time": "2024-03-12T00:00:00Z",
+        "data": {
+          "instant": {
+            "details": {
+              "air_pressure_at_sea_level": 1012.2,
+              "air_temperature": 7.5,
+              "cloud_area_fraction": 100.0,
+              "cloud_area_fraction_high": 100.0,
+              "cloud_area_fraction_low": 82.0,
+              "cloud_area_fraction_medium": 0.0,
+              "dew_point_temperature": 4.8,
+              "fog_area_fraction": 0.0,
+              "relative_humidity": 82.3,
+              "ultraviolet_index_clear_sky": 0.0,
+              "wind_from_direction": 269.5,
+              "wind_speed": 2.9
+            }
+          },
+          "next_12_hours": {
+            "summary": { "symbol_code": "lightrain" },
+            "details": {}
+          },
+          "next_1_hours": {
+            "summary": { "symbol_code": "cloudy" },
+            "details": { "precipitation_amount": 0.0 }
+          },
+          "next_6_hours": {
+            "summary": { "symbol_code": "cloudy" },
+            "details": {
+              "air_temperature_max": 7.0,
+              "air_temperature_min": 6.1,
+              "precipitation_amount": 0.2
+            }
+          }
+        }
+      },
+      {
+        "time": "2024-03-12T01:00:00Z",
+        "data": {
+          "instant": {
+            "details": {
+              "air_pressure_at_sea_level": 1012.3,
+              "air_temperature": 7.0,
+              "cloud_area_fraction": 100.0,
+              "cloud_area_fraction_high": 100.0,
+              "cloud_area_fraction_low": 95.3,
+              "cloud_area_fraction_medium": 0.8,
+              "dew_point_temperature": 4.8,
+              "fog_area_fraction": 0.0,
+              "relative_humidity": 84.8,
+              "ultraviolet_index_clear_sky": 0.0,
+              "wind_from_direction": 247.1,
+              "wind_speed": 3.0
+            }
+          },
+          "next_12_hours": {
+            "summary": { "symbol_code": "lightrain" },
+            "details": {}
+          },
+          "next_1_hours": {
+            "summary": { "symbol_code": "cloudy" },
+            "details": { "precipitation_amount": 0.0 }
+          },
+          "next_6_hours": {
+            "summary": { "symbol_code": "cloudy" },
+            "details": {
+              "air_temperature_max": 6.8,
+              "air_temperature_min": 6.1,
+              "precipitation_amount": 0.4
+            }
+          }
+        }
+      },
+      {
+        "time": "2024-03-12T02:00:00Z",
+        "data": {
+          "instant": {
+            "details": {
+              "air_pressure_at_sea_level": 1012.4,
+              "air_temperature": 6.7,
+              "cloud_area_fraction": 100.0,
+              "cloud_area_fraction_high": 100.0,
+              "cloud_area_fraction_low": 100.0,
+              "cloud_area_fraction_medium": 18.0,
+              "dew_point_temperature": 5.1,
+              "fog_area_fraction": 0.0,
+              "relative_humidity": 88.8,
+              "ultraviolet_index_clear_sky": 0.0,
+              "wind_from_direction": 246.3,
+              "wind_speed": 3.1
+            }
+          },
+          "next_12_hours": {
+            "summary": { "symbol_code": "lightrain" },
+            "details": {}
+          },
+          "next_1_hours": {
+            "summary": { "symbol_code": "cloudy" },
+            "details": { "precipitation_amount": 0.0 }
+          },
+          "next_6_hours": {
+            "summary": { "symbol_code": "lightrain" },
+            "details": {
+              "air_temperature_max": 7.1,
+              "air_temperature_min": 6.1,
+              "precipitation_amount": 0.9
+            }
+          }
+        }
+      },
+      {
+        "time": "2024-03-12T03:00:00Z",
+        "data": {
+          "instant": {
+            "details": {
+              "air_pressure_at_sea_level": 1012.3,
+              "air_temperature": 6.8,
+              "cloud_area_fraction": 100.0,
+              "cloud_area_fraction_high": 100.0,
+              "cloud_area_fraction_low": 93.7,
+              "cloud_area_fraction_medium": 27.3,
+              "dew_point_temperature": 5.7,
+              "fog_area_fraction": 0.0,
+              "relative_humidity": 92.5,
+              "ultraviolet_index_clear_sky": 0.0,
+              "wind_from_direction": 249.1,
+              "wind_speed": 3.3
+            }
+          },
+          "next_12_hours": {
+            "summary": { "symbol_code": "rain" },
+            "details": {}
+          },
+          "next_1_hours": {
+            "summary": { "symbol_code": "cloudy" },
+            "details": { "precipitation_amount": 0.0 }
+          },
+          "next_6_hours": {
+            "summary": { "symbol_code": "rain" },
+            "details": {
+              "air_temperature_max": 7.7,
+              "air_temperature_min": 6.1,
+              "precipitation_amount": 1.9
+            }
+          }
+        }
+      },
+      {
+        "time": "2024-03-12T04:00:00Z",
+        "data": {
+          "instant": {
+            "details": {
+              "air_pressure_at_sea_level": 1012.4,
+              "air_temperature": 6.5,
+              "cloud_area_fraction": 100.0,
+              "cloud_area_fraction_high": 100.0,
+              "cloud_area_fraction_low": 31.2,
+              "cloud_area_fraction_medium": 71.9,
+              "dew_point_temperature": 5.8,
+              "fog_area_fraction": 0.0,
+              "relative_humidity": 94.7,
+              "ultraviolet_index_clear_sky": 0.0,
+              "wind_from_direction": 248.1,
+              "wind_speed": 3.7
+            }
+          },
+          "next_12_hours": {
+            "summary": { "symbol_code": "rain" },
+            "details": {}
+          },
+          "next_1_hours": {
+            "summary": { "symbol_code": "cloudy" },
+            "details": { "precipitation_amount": 0.0 }
+          },
+          "next_6_hours": {
+            "summary": { "symbol_code": "rain" },
+            "details": {
+              "air_temperature_max": 8.6,
+              "air_temperature_min": 6.1,
+              "precipitation_amount": 2.7
+            }
+          }
+        }
+      },
+      {
+        "time": "2024-03-12T05:00:00Z",
+        "data": {
+          "instant": {
+            "details": {
+              "air_pressure_at_sea_level": 1012.8,
+              "air_temperature": 6.1,
+              "cloud_area_fraction": 100.0,
+              "cloud_area_fraction_high": 100.0,
+              "cloud_area_fraction_low": 15.6,
+              "cloud_area_fraction_medium": 100.0,
+              "dew_point_temperature": 5.2,
+              "fog_area_fraction": 0.0,
+              "relative_humidity": 92.9,
+              "ultraviolet_index_clear_sky": 0.0,
+              "wind_from_direction": 241.4,
+              "wind_speed": 3.4
+            }
+          },
+          "next_12_hours": {
+            "summary": { "symbol_code": "rain" },
+            "details": {}
+          },
+          "next_1_hours": {
+            "summary": { "symbol_code": "lightrain" },
+            "details": { "precipitation_amount": 0.1 }
+          },
+          "next_6_hours": {
+            "summary": { "symbol_code": "rain" },
+            "details": {
+              "air_temperature_max": 10.0,
+              "air_temperature_min": 6.5,
+              "precipitation_amount": 3.0
+            }
+          }
+        }
+      },
+      {
+        "time": "2024-03-12T06:00:00Z",
+        "data": {
+          "instant": {
+            "details": {
+              "air_pressure_at_sea_level": 1012.9,
+              "air_temperature": 6.5,
+              "cloud_area_fraction": 100.0,
+              "cloud_area_fraction_high": 100.0,
+              "cloud_area_fraction_low": 100.0,
+              "cloud_area_fraction_medium": 100.0,
+              "dew_point_temperature": 4.9,
+              "fog_area_fraction": 0.0,
+              "relative_humidity": 88.4,
+              "ultraviolet_index_clear_sky": 0.0,
+              "wind_from_direction": 231.2,
+              "wind_speed": 3.4
+            }
+          },
+          "next_12_hours": {
+            "summary": { "symbol_code": "lightrain" },
+            "details": {}
+          },
+          "next_1_hours": {
+            "summary": { "symbol_code": "lightrain" },
+            "details": { "precipitation_amount": 0.2 }
+          },
+          "next_6_hours": {
+            "summary": { "symbol_code": "rain" },
+            "details": {
+              "air_temperature_max": 11.0,
+              "air_temperature_min": 6.8,
+              "precipitation_amount": 3.1
+            }
+          }
+        }
+      },
+      {
+        "time": "2024-03-12T07:00:00Z",
+        "data": {
+          "instant": {
+            "details": {
+              "air_pressure_at_sea_level": 1013.0,
+              "air_temperature": 6.8,
+              "cloud_area_fraction": 100.0,
+              "cloud_area_fraction_high": 100.0,
+              "cloud_area_fraction_low": 100.0,
+              "cloud_area_fraction_medium": 100.0,
+              "dew_point_temperature": 5.0,
+              "fog_area_fraction": 0.0,
+              "relative_humidity": 87.3,
+              "ultraviolet_index_clear_sky": 0.1,
+              "wind_from_direction": 224.2,
+              "wind_speed": 3.5
+            }
+          },
+          "next_12_hours": {
+            "summary": { "symbol_code": "lightrain" },
+            "details": {}
+          },
+          "next_1_hours": {
+            "summary": { "symbol_code": "rain" },
+            "details": { "precipitation_amount": 0.5 }
+          },
+          "next_6_hours": {
+            "summary": { "symbol_code": "rain" },
+            "details": {
+              "air_temperature_max": 12.7,
+              "air_temperature_min": 7.1,
+              "precipitation_amount": 3.1
+            }
+          }
+        }
+      },
+      {
+        "time": "2024-03-12T08:00:00Z",
+        "data": {
+          "instant": {
+            "details": {
+              "air_pressure_at_sea_level": 1012.8,
+              "air_temperature": 7.1,
+              "cloud_area_fraction": 100.0,
+              "cloud_area_fraction_high": 100.0,
+              "cloud_area_fraction_low": 100.0,
+              "cloud_area_fraction_medium": 100.0,
+              "dew_point_temperature": 5.7,
+              "fog_area_fraction": 0.0,
+              "relative_humidity": 89.9,
+              "ultraviolet_index_clear_sky": 0.5,
+              "wind_from_direction": 201.3,
+              "wind_speed": 3.5
+            }
+          },
+          "next_12_hours": {
+            "summary": { "symbol_code": "lightrain" },
+            "details": {}
+          },
+          "next_1_hours": {
+            "summary": { "symbol_code": "heavyrain" },
+            "details": { "precipitation_amount": 1.0 }
+          },
+          "next_6_hours": {
+            "summary": { "symbol_code": "rain" },
+            "details": {
+              "air_temperature_max": 12.7,
+              "air_temperature_min": 7.7,
+              "precipitation_amount": 3.0
+            }
+          }
+        }
+      },
+      {
+        "time": "2024-03-12T09:00:00Z",
+        "data": {
+          "instant": {
+            "details": {
+              "air_pressure_at_sea_level": 1012.7,
+              "air_temperature": 7.7,
+              "cloud_area_fraction": 100.0,
+              "cloud_area_fraction_high": 100.0,
+              "cloud_area_fraction_low": 100.0,
+              "cloud_area_fraction_medium": 100.0,
+              "dew_point_temperature": 6.4,
+              "fog_area_fraction": 0.0,
+              "relative_humidity": 91.2,
+              "ultraviolet_index_clear_sky": 1.1,
+              "wind_from_direction": 190.2,
+              "wind_speed": 4.5
+            }
+          },
+          "next_12_hours": {
+            "summary": { "symbol_code": "lightrain" },
+            "details": {}
+          },
+          "next_1_hours": {
+            "summary": { "symbol_code": "rain" },
+            "details": { "precipitation_amount": 0.8 }
+          },
+          "next_6_hours": {
+            "summary": { "symbol_code": "rain" },
+            "details": {
+              "air_temperature_max": 13.1,
+              "air_temperature_min": 8.6,
+              "precipitation_amount": 2.2
+            }
+          }
+        }
+      },
+      {
+        "time": "2024-03-12T10:00:00Z",
+        "data": {
+          "instant": {
+            "details": {
+              "air_pressure_at_sea_level": 1012.4,
+              "air_temperature": 8.6,
+              "cloud_area_fraction": 100.0,
+              "cloud_area_fraction_high": 100.0,
+              "cloud_area_fraction_low": 100.0,
+              "cloud_area_fraction_medium": 98.4,
+              "dew_point_temperature": 7.5,
+              "fog_area_fraction": 0.0,
+              "relative_humidity": 93.2,
+              "ultraviolet_index_clear_sky": 1.8,
+              "wind_from_direction": 199.4,
+              "wind_speed": 5.0
+            }
+          },
+          "next_12_hours": {
+            "summary": { "symbol_code": "lightrain" },
+            "details": {}
+          },
+          "next_1_hours": {
+            "summary": { "symbol_code": "rain" },
+            "details": { "precipitation_amount": 0.3 }
+          },
+          "next_6_hours": {
+            "summary": { "symbol_code": "rain" },
+            "details": {
+              "air_temperature_max": 13.1,
+              "air_temperature_min": 10.0,
+              "precipitation_amount": 1.6
+            }
+          }
+        }
+      },
+      {
+        "time": "2024-03-12T11:00:00Z",
+        "data": {
+          "instant": {
+            "details": {
+              "air_pressure_at_sea_level": 1012.5,
+              "air_temperature": 10.0,
+              "cloud_area_fraction": 100.0,
+              "cloud_area_fraction_high": 100.0,
+              "cloud_area_fraction_low": 100.0,
+              "cloud_area_fraction_medium": 100.0,
+              "dew_point_temperature": 9.0,
+              "fog_area_fraction": 0.0,
+              "relative_humidity": 94.3,
+              "ultraviolet_index_clear_sky": 2.4,
+              "wind_from_direction": 216.5,
+              "wind_speed": 4.5
+            }
+          },
+          "next_12_hours": {
+            "summary": { "symbol_code": "lightrain" },
+            "details": {}
+          },
+          "next_1_hours": {
+            "summary": { "symbol_code": "rain" },
+            "details": { "precipitation_amount": 0.3 }
+          },
+          "next_6_hours": {
+            "summary": { "symbol_code": "rain" },
+            "details": {
+              "air_temperature_max": 13.1,
+              "air_temperature_min": 11.0,
+              "precipitation_amount": 1.2
+            }
+          }
+        }
+      },
+      {
+        "time": "2024-03-12T12:00:00Z",
+        "data": {
+          "instant": {
+            "details": {
+              "air_pressure_at_sea_level": 1012.3,
+              "air_temperature": 11.0,
+              "cloud_area_fraction": 100.0,
+              "cloud_area_fraction_high": 100.0,
+              "cloud_area_fraction_low": 100.0,
+              "cloud_area_fraction_medium": 100.0,
+              "dew_point_temperature": 9.8,
+              "fog_area_fraction": 0.0,
+              "relative_humidity": 91.8,
+              "ultraviolet_index_clear_sky": 2.7,
+              "wind_from_direction": 232.7,
+              "wind_speed": 4.8
+            }
+          },
+          "next_12_hours": {
+            "summary": { "symbol_code": "lightrain" },
+            "details": {}
+          },
+          "next_1_hours": {
+            "summary": { "symbol_code": "lightrain" },
+            "details": { "precipitation_amount": 0.1 }
+          },
+          "next_6_hours": {
+            "summary": { "symbol_code": "lightrain" },
+            "details": {
+              "air_temperature_max": 13.1,
+              "air_temperature_min": 12.0,
+              "precipitation_amount": 0.9
+            }
+          }
+        }
+      },
+      {
+        "time": "2024-03-12T13:00:00Z",
+        "data": {
+          "instant": {
+            "details": {
+              "air_pressure_at_sea_level": 1012.3,
+              "air_temperature": 12.7,
+              "cloud_area_fraction": 100.0,
+              "cloud_area_fraction_high": 100.0,
+              "cloud_area_fraction_low": 89.1,
+              "cloud_area_fraction_medium": 100.0,
+              "dew_point_temperature": 10.7,
+              "fog_area_fraction": 0.0,
+              "relative_humidity": 86.6,
+              "ultraviolet_index_clear_sky": 2.5,
+              "wind_from_direction": 247.2,
+              "wind_speed": 5.6
+            }
+          },
+          "next_12_hours": {
+            "summary": { "symbol_code": "lightrain" },
+            "details": {}
+          },
+          "next_1_hours": {
+            "summary": { "symbol_code": "rain" },
+            "details": { "precipitation_amount": 0.5 }
+          },
+          "next_6_hours": {
+            "summary": { "symbol_code": "lightrain" },
+            "details": {
+              "air_temperature_max": 13.1,
+              "air_temperature_min": 11.7,
+              "precipitation_amount": 0.8
+            }
+          }
+        }
+      },
+      {
+        "time": "2024-03-12T14:00:00Z",
+        "data": {
+          "instant": {
+            "details": {
+              "air_pressure_at_sea_level": 1012.1,
+              "air_temperature": 12.4,
+              "cloud_area_fraction": 100.0,
+              "cloud_area_fraction_high": 100.0,
+              "cloud_area_fraction_low": 10.9,
+              "cloud_area_fraction_medium": 100.0,
+              "dew_point_temperature": 11.0,
+              "fog_area_fraction": 0.0,
+              "relative_humidity": 91.0,
+              "ultraviolet_index_clear_sky": 1.9,
+              "wind_from_direction": 242.9,
+              "wind_speed": 5.0
+            }
+          },
+          "next_12_hours": {
+            "summary": { "symbol_code": "cloudy" },
+            "details": {}
+          },
+          "next_1_hours": {
+            "summary": { "symbol_code": "lightrain" },
+            "details": { "precipitation_amount": 0.2 }
+          },
+          "next_6_hours": {
+            "summary": { "symbol_code": "cloudy" },
+            "details": {
+              "air_temperature_max": 13.1,
+              "air_temperature_min": 11.4,
+              "precipitation_amount": 0.4
+            }
+          }
+        }
+      },
+      {
+        "time": "2024-03-12T15:00:00Z",
+        "data": {
+          "instant": {
+            "details": {
+              "air_pressure_at_sea_level": 1012.2,
+              "air_temperature": 13.1,
+              "cloud_area_fraction": 100.0,
+              "cloud_area_fraction_high": 100.0,
+              "cloud_area_fraction_low": 11.7,
+              "cloud_area_fraction_medium": 100.0,
+              "dew_point_temperature": 11.0,
+              "fog_area_fraction": 0.0,
+              "relative_humidity": 87.0,
+              "ultraviolet_index_clear_sky": 1.1,
+              "wind_from_direction": 246.4,
+              "wind_speed": 5.4
+            }
+          },
+          "next_12_hours": {
+            "summary": { "symbol_code": "cloudy" },
+            "details": {}
+          },
+          "next_1_hours": {
+            "summary": { "symbol_code": "lightrain" },
+            "details": { "precipitation_amount": 0.1 }
+          },
+          "next_6_hours": {
+            "summary": { "symbol_code": "cloudy" },
+            "details": {
+              "air_temperature_max": 13.1,
+              "air_temperature_min": 11.0,
+              "precipitation_amount": 0.2
+            }
+          }
+        }
+      },
+      {
+        "time": "2024-03-12T16:00:00Z",
+        "data": {
+          "instant": {
+            "details": {
+              "air_pressure_at_sea_level": 1012.2,
+              "air_temperature": 12.6,
+              "cloud_area_fraction": 96.9,
+              "cloud_area_fraction_high": 92.2,
+              "cloud_area_fraction_low": 20.3,
+              "cloud_area_fraction_medium": 55.5,
+              "dew_point_temperature": 11.0,
+              "fog_area_fraction": 0.0,
+              "relative_humidity": 89.8,
+              "ultraviolet_index_clear_sky": 0.5,
+              "wind_from_direction": 234.5,
+              "wind_speed": 4.5
+            }
+          },
+          "next_12_hours": {
+            "summary": { "symbol_code": "cloudy" },
+            "details": {}
+          },
+          "next_1_hours": {
+            "summary": { "symbol_code": "cloudy" },
+            "details": { "precipitation_amount": 0.0 }
+          },
+          "next_6_hours": {
+            "summary": { "symbol_code": "cloudy" },
+            "details": {
+              "air_temperature_max": 13.1,
+              "air_temperature_min": 10.9,
+              "precipitation_amount": 0.3
+            }
+          }
+        }
+      },
+      {
+        "time": "2024-03-12T17:00:00Z",
+        "data": {
+          "instant": {
+            "details": {
+              "air_pressure_at_sea_level": 1012.3,
+              "air_temperature": 13.1,
+              "cloud_area_fraction": 100.0,
+              "cloud_area_fraction_high": 96.1,
+              "cloud_area_fraction_low": 23.4,
+              "cloud_area_fraction_medium": 92.2,
+              "dew_point_temperature": 11.2,
+              "fog_area_fraction": 0.0,
+              "relative_humidity": 88.2,
+              "ultraviolet_index_clear_sky": 0.1,
+              "wind_from_direction": 227.9,
+              "wind_speed": 4.5
+            }
+          },
+          "next_12_hours": {
+            "summary": { "symbol_code": "cloudy" },
+            "details": {}
+          },
+          "next_1_hours": {
+            "summary": { "symbol_code": "cloudy" },
+            "details": { "precipitation_amount": 0.0 }
+          },
+          "next_6_hours": {
+            "summary": { "symbol_code": "cloudy" },
+            "details": {
+              "air_temperature_max": 12.0,
+              "air_temperature_min": 10.7,
+              "precipitation_amount": 0.3
+            }
+          }
+        }
+      },
+      {
+        "time": "2024-03-12T18:00:00Z",
+        "data": {
+          "instant": {
+            "details": {
+              "air_pressure_at_sea_level": 1012.6,
+              "air_temperature": 12.0,
+              "cloud_area_fraction": 100.0,
+              "cloud_area_fraction_high": 100.0,
+              "cloud_area_fraction_low": 9.4,
+              "cloud_area_fraction_medium": 99.2,
+              "dew_point_temperature": 10.7,
+              "fog_area_fraction": 0.0,
+              "relative_humidity": 91.3,
+              "ultraviolet_index_clear_sky": 0.0,
+              "wind_from_direction": 223.2,
+              "wind_speed": 4.6
+            }
+          },
+          "next_12_hours": {
+            "summary": { "symbol_code": "cloudy" },
+            "details": {}
+          },
+          "next_1_hours": {
+            "summary": { "symbol_code": "cloudy" },
+            "details": { "precipitation_amount": 0.0 }
+          },
+          "next_6_hours": {
+            "summary": { "symbol_code": "cloudy" },
+            "details": {
+              "air_temperature_max": 11.7,
+              "air_temperature_min": 10.4,
+              "precipitation_amount": 0.3
+            }
+          }
+        }
+      },
+      {
+        "time": "2024-03-12T19:00:00Z",
+        "data": {
+          "instant": {
+            "details": {
+              "air_pressure_at_sea_level": 1013.1,
+              "air_temperature": 11.7,
+              "cloud_area_fraction": 100.0,
+              "cloud_area_fraction_high": 100.0,
+              "cloud_area_fraction_low": 4.7,
+              "cloud_area_fraction_medium": 100.0,
+              "dew_point_temperature": 10.5,
+              "fog_area_fraction": 0.0,
+              "relative_humidity": 91.8,
+              "ultraviolet_index_clear_sky": 0.0,
+              "wind_from_direction": 226.0,
+              "wind_speed": 5.3
+            }
+          },
+          "next_12_hours": {
+            "summary": { "symbol_code": "cloudy" },
+            "details": {}
+          },
+          "next_1_hours": {
+            "summary": { "symbol_code": "cloudy" },
+            "details": { "precipitation_amount": 0.0 }
+          },
+          "next_6_hours": {
+            "summary": { "symbol_code": "cloudy" },
+            "details": {
+              "air_temperature_max": 11.4,
+              "air_temperature_min": 10.4,
+              "precipitation_amount": 0.3
+            }
+          }
+        }
+      },
+      {
+        "time": "2024-03-12T20:00:00Z",
+        "data": {
+          "instant": {
+            "details": {
+              "air_pressure_at_sea_level": 1013.6,
+              "air_temperature": 11.4,
+              "cloud_area_fraction": 100.0,
+              "cloud_area_fraction_high": 99.2,
+              "cloud_area_fraction_low": 3.1,
+              "cloud_area_fraction_medium": 76.6,
+              "dew_point_temperature": 10.3,
+              "fog_area_fraction": 0.0,
+              "relative_humidity": 92.0,
+              "ultraviolet_index_clear_sky": 0.0,
+              "wind_from_direction": 228.6,
+              "wind_speed": 5.3
+            }
+          },
+          "next_12_hours": {
+            "summary": { "symbol_code": "cloudy" },
+            "details": {}
+          },
+          "next_1_hours": {
+            "summary": { "symbol_code": "cloudy" },
+            "details": { "precipitation_amount": 0.0 }
+          },
+          "next_6_hours": {
+            "summary": { "symbol_code": "cloudy" },
+            "details": {
+              "air_temperature_max": 11.0,
+              "air_temperature_min": 10.4,
+              "precipitation_amount": 0.3
+            }
+          }
+        }
+      },
+      {
+        "time": "2024-03-12T21:00:00Z",
+        "data": {
+          "instant": {
+            "details": {
+              "air_pressure_at_sea_level": 1013.8,
+              "air_temperature": 11.0,
+              "cloud_area_fraction": 100.0,
+              "cloud_area_fraction_high": 92.2,
+              "cloud_area_fraction_low": 6.2,
+              "cloud_area_fraction_medium": 100.0,
+              "dew_point_temperature": 10.0,
+              "fog_area_fraction": 0.0,
+              "relative_humidity": 92.4,
+              "ultraviolet_index_clear_sky": 0.0,
+              "wind_from_direction": 227.6,
+              "wind_speed": 5.0
+            }
+          },
+          "next_12_hours": {
+            "summary": { "symbol_code": "cloudy" },
+            "details": {}
+          },
+          "next_1_hours": {
+            "summary": { "symbol_code": "lightrain" },
+            "details": { "precipitation_amount": 0.2 }
+          },
+          "next_6_hours": {
+            "summary": { "symbol_code": "cloudy" },
+            "details": {
+              "air_temperature_max": 10.9,
+              "air_temperature_min": 10.4,
+              "precipitation_amount": 0.2
+            }
+          }
+        }
+      },
+      {
+        "time": "2024-03-12T22:00:00Z",
+        "data": {
+          "instant": {
+            "details": {
+              "air_pressure_at_sea_level": 1013.7,
+              "air_temperature": 10.9,
+              "cloud_area_fraction": 100.0,
+              "cloud_area_fraction_high": 97.7,
+              "cloud_area_fraction_low": 12.5,
+              "cloud_area_fraction_medium": 95.3,
+              "dew_point_temperature": 9.9,
+              "fog_area_fraction": 0.0,
+              "relative_humidity": 92.9,
+              "ultraviolet_index_clear_sky": 0.0,
+              "wind_from_direction": 229.2,
+              "wind_speed": 5.1
+            }
+          },
+          "next_12_hours": {
+            "summary": { "symbol_code": "cloudy" },
+            "details": {}
+          },
+          "next_1_hours": {
+            "summary": { "symbol_code": "cloudy" },
+            "details": { "precipitation_amount": 0.0 }
+          },
+          "next_6_hours": {
+            "summary": { "symbol_code": "cloudy" },
+            "details": {
+              "air_temperature_max": 10.7,
+              "air_temperature_min": 10.4,
+              "precipitation_amount": 0.0
+            }
+          }
+        }
+      },
+      {
+        "time": "2024-03-12T23:00:00Z",
+        "data": {
+          "instant": {
+            "details": {
+              "air_pressure_at_sea_level": 1013.7,
+              "air_temperature": 10.7,
+              "cloud_area_fraction": 98.4,
+              "cloud_area_fraction_high": 88.3,
+              "cloud_area_fraction_low": 57.0,
+              "cloud_area_fraction_medium": 63.3,
+              "dew_point_temperature": 9.7,
+              "fog_area_fraction": 0.0,
+              "relative_humidity": 93.4,
+              "ultraviolet_index_clear_sky": 0.0,
+              "wind_from_direction": 231.3,
+              "wind_speed": 5.3
+            }
+          },
+          "next_12_hours": {
+            "summary": { "symbol_code": "cloudy" },
+            "details": {}
+          },
+          "next_1_hours": {
+            "summary": { "symbol_code": "cloudy" },
+            "details": { "precipitation_amount": 0.0 }
+          },
+          "next_6_hours": {
+            "summary": { "symbol_code": "cloudy" },
+            "details": {
+              "air_temperature_max": 10.6,
+              "air_temperature_min": 10.4,
+              "precipitation_amount": 0.0
+            }
+          }
+        }
+      },
+      {
+        "time": "2024-03-13T00:00:00Z",
+        "data": {
+          "instant": {
+            "details": {
+              "air_pressure_at_sea_level": 1013.5,
+              "air_temperature": 10.4,
+              "cloud_area_fraction": 99.2,
+              "cloud_area_fraction_high": 79.7,
+              "cloud_area_fraction_low": 93.7,
+              "cloud_area_fraction_medium": 48.4,
+              "dew_point_temperature": 9.5,
+              "fog_area_fraction": 0.0,
+              "relative_humidity": 94.0,
+              "ultraviolet_index_clear_sky": 0.0,
+              "wind_from_direction": 224.3,
+              "wind_speed": 5.4
+            }
+          },
+          "next_12_hours": {
+            "summary": { "symbol_code": "cloudy" },
+            "details": {}
+          },
+          "next_1_hours": {
+            "summary": { "symbol_code": "cloudy" },
+            "details": { "precipitation_amount": 0.0 }
+          },
+          "next_6_hours": {
+            "summary": { "symbol_code": "cloudy" },
+            "details": {
+              "air_temperature_max": 10.6,
+              "air_temperature_min": 10.5,
+              "precipitation_amount": 0.0
+            }
+          }
+        }
+      },
+      {
+        "time": "2024-03-13T01:00:00Z",
+        "data": {
+          "instant": {
+            "details": {
+              "air_pressure_at_sea_level": 1013.4,
+              "air_temperature": 10.5,
+              "cloud_area_fraction": 100.0,
+              "cloud_area_fraction_high": 65.6,
+              "cloud_area_fraction_low": 100.0,
+              "cloud_area_fraction_medium": 39.8,
+              "dew_point_temperature": 9.5,
+              "fog_area_fraction": 0.0,
+              "relative_humidity": 94.1,
+              "ultraviolet_index_clear_sky": 0.0,
+              "wind_from_direction": 222.2,
+              "wind_speed": 5.4
+            }
+          },
+          "next_1_hours": {
+            "summary": { "symbol_code": "cloudy" },
+            "details": { "precipitation_amount": 0.0 }
+          },
+          "next_6_hours": {
+            "summary": { "symbol_code": "cloudy" },
+            "details": {
+              "air_temperature_max": 10.6,
+              "air_temperature_min": 10.5,
+              "precipitation_amount": 0.0
+            }
+          }
+        }
+      },
+      {
+        "time": "2024-03-13T02:00:00Z",
+        "data": {
+          "instant": {
+            "details": {
+              "air_pressure_at_sea_level": 1013.3,
+              "air_temperature": 10.6,
+              "cloud_area_fraction": 100.0,
+              "cloud_area_fraction_high": 98.4,
+              "cloud_area_fraction_low": 100.0,
+              "cloud_area_fraction_medium": 90.6,
+              "dew_point_temperature": 9.5,
+              "fog_area_fraction": 0.0,
+              "relative_humidity": 93.2,
+              "ultraviolet_index_clear_sky": 0.0,
+              "wind_from_direction": 223.2,
+              "wind_speed": 5.5
+            }
+          },
+          "next_1_hours": {
+            "summary": { "symbol_code": "cloudy" },
+            "details": { "precipitation_amount": 0.0 }
+          },
+          "next_6_hours": {
+            "summary": { "symbol_code": "cloudy" },
+            "details": {
+              "air_temperature_max": 11.1,
+              "air_temperature_min": 10.5,
+              "precipitation_amount": 0.0
+            }
+          }
+        }
+      },
+      {
+        "time": "2024-03-13T03:00:00Z",
+        "data": {
+          "instant": {
+            "details": {
+              "air_pressure_at_sea_level": 1013.0,
+              "air_temperature": 10.6,
+              "cloud_area_fraction": 100.0,
+              "cloud_area_fraction_high": 89.8,
+              "cloud_area_fraction_low": 100.0,
+              "cloud_area_fraction_medium": 100.0,
+              "dew_point_temperature": 9.5,
+              "fog_area_fraction": 0.0,
+              "relative_humidity": 92.8,
+              "ultraviolet_index_clear_sky": 0.0,
+              "wind_from_direction": 223.4,
+              "wind_speed": 5.7
+            }
+          },
+          "next_1_hours": {
+            "summary": { "symbol_code": "cloudy" },
+            "details": { "precipitation_amount": 0.0 }
+          },
+          "next_6_hours": {
+            "summary": { "symbol_code": "cloudy" },
+            "details": {
+              "air_temperature_max": 11.9,
+              "air_temperature_min": 10.5,
+              "precipitation_amount": 0.0
+            }
+          }
+        }
+      },
+      {
+        "time": "2024-03-13T04:00:00Z",
+        "data": {
+          "instant": {
+            "details": {
+              "air_pressure_at_sea_level": 1012.8,
+              "air_temperature": 10.6,
+              "cloud_area_fraction": 100.0,
+              "cloud_area_fraction_high": 97.7,
+              "cloud_area_fraction_low": 100.0,
+              "cloud_area_fraction_medium": 91.4,
+              "dew_point_temperature": 9.4,
+              "fog_area_fraction": 0.0,
+              "relative_humidity": 92.3,
+              "ultraviolet_index_clear_sky": 0.0,
+              "wind_from_direction": 224.4,
+              "wind_speed": 5.8
+            }
+          },
+          "next_1_hours": {
+            "summary": { "symbol_code": "cloudy" },
+            "details": { "precipitation_amount": 0.0 }
+          },
+          "next_6_hours": {
+            "summary": { "symbol_code": "cloudy" },
+            "details": {
+              "air_temperature_max": 12.6,
+              "air_temperature_min": 10.5,
+              "precipitation_amount": 0.0
+            }
+          }
+        }
+      },
+      {
+        "time": "2024-03-13T05:00:00Z",
+        "data": {
+          "instant": {
+            "details": {
+              "air_pressure_at_sea_level": 1012.4,
+              "air_temperature": 10.6,
+              "cloud_area_fraction": 100.0,
+              "cloud_area_fraction_high": 99.2,
+              "cloud_area_fraction_low": 100.0,
+              "cloud_area_fraction_medium": 88.3,
+              "dew_point_temperature": 9.2,
+              "fog_area_fraction": 0.0,
+              "relative_humidity": 91.4,
+              "ultraviolet_index_clear_sky": 0.0,
+              "wind_from_direction": 221.7,
+              "wind_speed": 5.9
+            }
+          },
+          "next_1_hours": {
+            "summary": { "symbol_code": "cloudy" },
+            "details": { "precipitation_amount": 0.0 }
+          },
+          "next_6_hours": {
+            "summary": { "symbol_code": "cloudy" },
+            "details": {
+              "air_temperature_max": 12.8,
+              "air_temperature_min": 10.5,
+              "precipitation_amount": 0.1
+            }
+          }
+        }
+      },
+      {
+        "time": "2024-03-13T06:00:00Z",
+        "data": {
+          "instant": {
+            "details": {
+              "air_pressure_at_sea_level": 1012.4,
+              "air_temperature": 10.5,
+              "cloud_area_fraction": 100.0,
+              "cloud_area_fraction_high": 100.0,
+              "cloud_area_fraction_low": 100.0,
+              "cloud_area_fraction_medium": 100.0,
+              "dew_point_temperature": 9.2,
+              "fog_area_fraction": 0.0,
+              "relative_humidity": 91.7,
+              "ultraviolet_index_clear_sky": 0.0,
+              "wind_from_direction": 221.2,
+              "wind_speed": 6.0
+            }
+          },
+          "next_12_hours": {
+            "summary": { "symbol_code": "cloudy" },
+            "details": {}
+          },
+          "next_1_hours": {
+            "summary": { "symbol_code": "cloudy" },
+            "details": { "precipitation_amount": 0.0 }
+          },
+          "next_6_hours": {
+            "summary": { "symbol_code": "cloudy" },
+            "details": {
+              "air_temperature_max": 12.8,
+              "air_temperature_min": 10.6,
+              "precipitation_amount": 0.1
+            }
+          }
+        }
+      },
+      {
+        "time": "2024-03-13T07:00:00Z",
+        "data": {
+          "instant": {
+            "details": {
+              "air_pressure_at_sea_level": 1012.7,
+              "air_temperature": 10.6,
+              "cloud_area_fraction": 100.0,
+              "cloud_area_fraction_high": 100.0,
+              "cloud_area_fraction_low": 100.0,
+              "cloud_area_fraction_medium": 93.7,
+              "dew_point_temperature": 9.3,
+              "fog_area_fraction": 0.0,
+              "relative_humidity": 91.4,
+              "ultraviolet_index_clear_sky": 0.1,
+              "wind_from_direction": 221.7,
+              "wind_speed": 6.3
+            }
+          },
+          "next_1_hours": {
+            "summary": { "symbol_code": "cloudy" },
+            "details": { "precipitation_amount": 0.0 }
+          }
+        }
+      },
+      {
+        "time": "2024-03-13T08:00:00Z",
+        "data": {
+          "instant": {
+            "details": {
+              "air_pressure_at_sea_level": 1013.1,
+              "air_temperature": 11.1,
+              "cloud_area_fraction": 100.0,
+              "cloud_area_fraction_high": 100.0,
+              "cloud_area_fraction_low": 98.4,
+              "cloud_area_fraction_medium": 6.2,
+              "dew_point_temperature": 9.3,
+              "fog_area_fraction": 0.0,
+              "relative_humidity": 88.2,
+              "ultraviolet_index_clear_sky": 0.5,
+              "wind_from_direction": 222.2,
+              "wind_speed": 6.9
+            }
+          },
+          "next_1_hours": {
+            "summary": { "symbol_code": "cloudy" },
+            "details": { "precipitation_amount": 0.0 }
+          }
+        }
+      },
+      {
+        "time": "2024-03-13T09:00:00Z",
+        "data": {
+          "instant": {
+            "details": {
+              "air_pressure_at_sea_level": 1013.1,
+              "air_temperature": 11.9,
+              "cloud_area_fraction": 100.0,
+              "cloud_area_fraction_high": 100.0,
+              "cloud_area_fraction_low": 83.6,
+              "cloud_area_fraction_medium": 95.3,
+              "dew_point_temperature": 9.2,
+              "fog_area_fraction": 0.0,
+              "relative_humidity": 83.2,
+              "ultraviolet_index_clear_sky": 1.1,
+              "wind_from_direction": 220.5,
+              "wind_speed": 7.2
+            }
+          },
+          "next_1_hours": {
+            "summary": { "symbol_code": "cloudy" },
+            "details": { "precipitation_amount": 0.0 }
+          }
+        }
+      },
+      {
+        "time": "2024-03-13T10:00:00Z",
+        "data": {
+          "instant": {
+            "details": {
+              "air_pressure_at_sea_level": 1013.2,
+              "air_temperature": 12.6,
+              "cloud_area_fraction": 100.0,
+              "cloud_area_fraction_high": 100.0,
+              "cloud_area_fraction_low": 75.0,
+              "cloud_area_fraction_medium": 92.2,
+              "dew_point_temperature": 9.2,
+              "fog_area_fraction": 0.0,
+              "relative_humidity": 79.3,
+              "ultraviolet_index_clear_sky": 1.9,
+              "wind_from_direction": 223.6,
+              "wind_speed": 9.3
+            }
+          },
+          "next_1_hours": {
+            "summary": { "symbol_code": "cloudy" },
+            "details": { "precipitation_amount": 0.0 }
+          }
+        }
+      },
+      {
+        "time": "2024-03-13T11:00:00Z",
+        "data": {
+          "instant": {
+            "details": {
+              "air_pressure_at_sea_level": 1013.3,
+              "air_temperature": 12.8,
+              "cloud_area_fraction": 100.0,
+              "cloud_area_fraction_high": 100.0,
+              "cloud_area_fraction_low": 95.3,
+              "cloud_area_fraction_medium": 95.3,
+              "dew_point_temperature": 9.4,
+              "fog_area_fraction": 0.0,
+              "relative_humidity": 79.5,
+              "ultraviolet_index_clear_sky": 2.6,
+              "wind_from_direction": 227.4,
+              "wind_speed": 9.7
+            }
+          },
+          "next_1_hours": {
+            "summary": { "symbol_code": "cloudy" },
+            "details": { "precipitation_amount": 0.0 }
+          }
+        }
+      },
+      {
+        "time": "2024-03-13T12:00:00Z",
+        "data": {
+          "instant": {
+            "details": {
+              "air_pressure_at_sea_level": 1013.3,
+              "air_temperature": 12.7,
+              "cloud_area_fraction": 100.0,
+              "cloud_area_fraction_high": 100.0,
+              "cloud_area_fraction_low": 100.0,
+              "cloud_area_fraction_medium": 32.0,
+              "dew_point_temperature": 9.2,
+              "fog_area_fraction": 0.0,
+              "relative_humidity": 79.1,
+              "ultraviolet_index_clear_sky": 2.8,
+              "wind_from_direction": 226.7,
+              "wind_speed": 8.6
+            }
+          },
+          "next_12_hours": {
+            "summary": { "symbol_code": "cloudy" },
+            "details": {}
+          },
+          "next_6_hours": {
+            "summary": { "symbol_code": "cloudy" },
+            "details": {
+              "air_temperature_max": 13.9,
+              "air_temperature_min": 12.1,
+              "precipitation_amount": 0.0
+            }
+          }
+        }
+      },
+      {
+        "time": "2024-03-13T18:00:00Z",
+        "data": {
+          "instant": {
+            "details": {
+              "air_pressure_at_sea_level": 1013.2,
+              "air_temperature": 12.1,
+              "cloud_area_fraction": 100.0,
+              "cloud_area_fraction_high": 100.0,
+              "cloud_area_fraction_low": 100.0,
+              "cloud_area_fraction_medium": 100.0,
+              "dew_point_temperature": 8.7,
+              "relative_humidity": 79.7,
+              "wind_from_direction": 221.4,
+              "wind_speed": 6.5
+            }
+          },
+          "next_12_hours": {
+            "summary": { "symbol_code": "cloudy" },
+            "details": {}
+          },
+          "next_6_hours": {
+            "summary": { "symbol_code": "cloudy" },
+            "details": {
+              "air_temperature_max": 12.1,
+              "air_temperature_min": 9.8,
+              "precipitation_amount": 0.0
+            }
+          }
+        }
+      },
+      {
+        "time": "2024-03-14T00:00:00Z",
+        "data": {
+          "instant": {
+            "details": {
+              "air_pressure_at_sea_level": 1012.9,
+              "air_temperature": 9.8,
+              "cloud_area_fraction": 83.6,
+              "cloud_area_fraction_high": 82.0,
+              "cloud_area_fraction_low": 2.3,
+              "cloud_area_fraction_medium": 14.8,
+              "dew_point_temperature": 8.2,
+              "relative_humidity": 90.8,
+              "wind_from_direction": 213.2,
+              "wind_speed": 4.9
+            }
+          },
+          "next_12_hours": {
+            "summary": { "symbol_code": "cloudy" },
+            "details": {}
+          },
+          "next_6_hours": {
+            "summary": { "symbol_code": "partlycloudy_night" },
+            "details": {
+              "air_temperature_max": 9.8,
+              "air_temperature_min": 8.9,
+              "precipitation_amount": 0.0
+            }
+          }
+        }
+      },
+      {
+        "time": "2024-03-14T06:00:00Z",
+        "data": {
+          "instant": {
+            "details": {
+              "air_pressure_at_sea_level": 1011.2,
+              "air_temperature": 8.9,
+              "cloud_area_fraction": 98.4,
+              "cloud_area_fraction_high": 97.7,
+              "cloud_area_fraction_low": 16.4,
+              "cloud_area_fraction_medium": 11.7,
+              "dew_point_temperature": 7.0,
+              "relative_humidity": 88.6,
+              "wind_from_direction": 216.0,
+              "wind_speed": 4.7
+            }
+          },
+          "next_12_hours": {
+            "summary": { "symbol_code": "cloudy" },
+            "details": {}
+          },
+          "next_6_hours": {
+            "summary": { "symbol_code": "cloudy" },
+            "details": {
+              "air_temperature_max": 15.0,
+              "air_temperature_min": 8.6,
+              "precipitation_amount": 0.0
+            }
+          }
+        }
+      },
+      {
+        "time": "2024-03-14T12:00:00Z",
+        "data": {
+          "instant": {
+            "details": {
+              "air_pressure_at_sea_level": 1009.4,
+              "air_temperature": 15.0,
+              "cloud_area_fraction": 100.0,
+              "cloud_area_fraction_high": 100.0,
+              "cloud_area_fraction_low": 27.3,
+              "cloud_area_fraction_medium": 89.1,
+              "dew_point_temperature": 8.6,
+              "relative_humidity": 65.8,
+              "wind_from_direction": 210.0,
+              "wind_speed": 6.9
+            }
+          },
+          "next_12_hours": {
+            "summary": { "symbol_code": "cloudy" },
+            "details": {}
+          },
+          "next_6_hours": {
+            "summary": { "symbol_code": "cloudy" },
+            "details": {
+              "air_temperature_max": 15.1,
+              "air_temperature_min": 12.4,
+              "precipitation_amount": 0.0
+            }
+          }
+        }
+      },
+      {
+        "time": "2024-03-14T18:00:00Z",
+        "data": {
+          "instant": {
+            "details": {
+              "air_pressure_at_sea_level": 1006.7,
+              "air_temperature": 12.4,
+              "cloud_area_fraction": 92.2,
+              "cloud_area_fraction_high": 41.4,
+              "cloud_area_fraction_low": 40.6,
+              "cloud_area_fraction_medium": 82.8,
+              "dew_point_temperature": 8.3,
+              "relative_humidity": 76.2,
+              "wind_from_direction": 207.3,
+              "wind_speed": 6.1
+            }
+          },
+          "next_12_hours": {
+            "summary": { "symbol_code": "cloudy" },
+            "details": {}
+          },
+          "next_6_hours": {
+            "summary": { "symbol_code": "cloudy" },
+            "details": {
+              "air_temperature_max": 12.5,
+              "air_temperature_min": 11.4,
+              "precipitation_amount": 0.1
+            }
+          }
+        }
+      },
+      {
+        "time": "2024-03-15T00:00:00Z",
+        "data": {
+          "instant": {
+            "details": {
+              "air_pressure_at_sea_level": 1005.8,
+              "air_temperature": 12.0,
+              "cloud_area_fraction": 100.0,
+              "cloud_area_fraction_high": 0.0,
+              "cloud_area_fraction_low": 100.0,
+              "cloud_area_fraction_medium": 0.0,
+              "dew_point_temperature": 10.2,
+              "relative_humidity": 88.0,
+              "wind_from_direction": 213.9,
+              "wind_speed": 6.4
+            }
+          },
+          "next_12_hours": {
+            "summary": { "symbol_code": "cloudy" },
+            "details": {}
+          },
+          "next_6_hours": {
+            "summary": { "symbol_code": "cloudy" },
+            "details": {
+              "air_temperature_max": 12.0,
+              "air_temperature_min": 11.1,
+              "precipitation_amount": 0.1
+            }
+          }
+        }
+      },
+      {
+        "time": "2024-03-15T06:00:00Z",
+        "data": {
+          "instant": {
+            "details": {
+              "air_pressure_at_sea_level": 1005.8,
+              "air_temperature": 11.4,
+              "cloud_area_fraction": 100.0,
+              "cloud_area_fraction_high": 2.3,
+              "cloud_area_fraction_low": 100.0,
+              "cloud_area_fraction_medium": 4.7,
+              "dew_point_temperature": 9.1,
+              "relative_humidity": 85.6,
+              "wind_from_direction": 214.3,
+              "wind_speed": 6.7
+            }
+          },
+          "next_12_hours": {
+            "summary": { "symbol_code": "cloudy" },
+            "details": {}
+          },
+          "next_6_hours": {
+            "summary": { "symbol_code": "cloudy" },
+            "details": {
+              "air_temperature_max": 14.7,
+              "air_temperature_min": 11.3,
+              "precipitation_amount": 0.3
+            }
+          }
+        }
+      },
+      {
+        "time": "2024-03-15T12:00:00Z",
+        "data": {
+          "instant": {
+            "details": {
+              "air_pressure_at_sea_level": 1006.1,
+              "air_temperature": 14.3,
+              "cloud_area_fraction": 99.2,
+              "cloud_area_fraction_high": 95.3,
+              "cloud_area_fraction_low": 72.7,
+              "cloud_area_fraction_medium": 11.7,
+              "dew_point_temperature": 9.4,
+              "relative_humidity": 72.3,
+              "wind_from_direction": 222.3,
+              "wind_speed": 9.8
+            }
+          },
+          "next_12_hours": {
+            "summary": { "symbol_code": "cloudy" },
+            "details": {}
+          },
+          "next_6_hours": {
+            "summary": { "symbol_code": "cloudy" },
+            "details": {
+              "air_temperature_max": 14.5,
+              "air_temperature_min": 12.2,
+              "precipitation_amount": 0.5
+            }
+          }
+        }
+      },
+      {
+        "time": "2024-03-15T18:00:00Z",
+        "data": {
+          "instant": {
+            "details": {
+              "air_pressure_at_sea_level": 1006.7,
+              "air_temperature": 12.2,
+              "cloud_area_fraction": 75.0,
+              "cloud_area_fraction_high": 45.3,
+              "cloud_area_fraction_low": 53.9,
+              "cloud_area_fraction_medium": 0.8,
+              "dew_point_temperature": 8.9,
+              "relative_humidity": 79.9,
+              "wind_from_direction": 237.6,
+              "wind_speed": 7.9
+            }
+          },
+          "next_12_hours": {
+            "summary": { "symbol_code": "cloudy" },
+            "details": {}
+          },
+          "next_6_hours": {
+            "summary": { "symbol_code": "partlycloudy_night" },
+            "details": {
+              "air_temperature_max": 12.2,
+              "air_temperature_min": 11.0,
+              "precipitation_amount": 0.0
+            }
+          }
+        }
+      },
+      {
+        "time": "2024-03-16T00:00:00Z",
+        "data": {
+          "instant": {
+            "details": {
+              "air_pressure_at_sea_level": 1011.5,
+              "air_temperature": 11.0,
+              "cloud_area_fraction": 96.1,
+              "cloud_area_fraction_high": 25.8,
+              "cloud_area_fraction_low": 93.0,
+              "cloud_area_fraction_medium": 0.0,
+              "dew_point_temperature": 7.7,
+              "relative_humidity": 80.6,
+              "wind_from_direction": 248.7,
+              "wind_speed": 6.6
+            }
+          },
+          "next_12_hours": {
+            "summary": { "symbol_code": "lightrain" },
+            "details": {}
+          },
+          "next_6_hours": {
+            "summary": { "symbol_code": "cloudy" },
+            "details": {
+              "air_temperature_max": 11.0,
+              "air_temperature_min": 7.6,
+              "precipitation_amount": 0.0
+            }
+          }
+        }
+      },
+      {
+        "time": "2024-03-16T06:00:00Z",
+        "data": {
+          "instant": {
+            "details": {
+              "air_pressure_at_sea_level": 1014.5,
+              "air_temperature": 7.6,
+              "cloud_area_fraction": 99.2,
+              "cloud_area_fraction_high": 92.2,
+              "cloud_area_fraction_low": 1.6,
+              "cloud_area_fraction_medium": 93.7,
+              "dew_point_temperature": 6.6,
+              "relative_humidity": 93.2,
+              "wind_from_direction": 237.0,
+              "wind_speed": 3.4
+            }
+          },
+          "next_12_hours": {
+            "summary": { "symbol_code": "rain" },
+            "details": {}
+          },
+          "next_6_hours": {
+            "summary": { "symbol_code": "rain" },
+            "details": {
+              "air_temperature_max": 13.5,
+              "air_temperature_min": 7.6,
+              "precipitation_amount": 1.3
+            }
+          }
+        }
+      },
+      {
+        "time": "2024-03-16T12:00:00Z",
+        "data": {
+          "instant": {
+            "details": {
+              "air_pressure_at_sea_level": 1015.0,
+              "air_temperature": 13.5,
+              "cloud_area_fraction": 100.0,
+              "cloud_area_fraction_high": 100.0,
+              "cloud_area_fraction_low": 100.0,
+              "cloud_area_fraction_medium": 89.8,
+              "dew_point_temperature": 10.9,
+              "relative_humidity": 84.1,
+              "wind_from_direction": 213.9,
+              "wind_speed": 7.1
+            }
+          },
+          "next_12_hours": {
+            "summary": { "symbol_code": "lightrain" },
+            "details": {}
+          },
+          "next_6_hours": {
+            "summary": { "symbol_code": "rain" },
+            "details": {
+              "air_temperature_max": 13.7,
+              "air_temperature_min": 11.9,
+              "precipitation_amount": 2.2
+            }
+          }
+        }
+      },
+      {
+        "time": "2024-03-16T18:00:00Z",
+        "data": {
+          "instant": {
+            "details": {
+              "air_pressure_at_sea_level": 1013.5,
+              "air_temperature": 11.9,
+              "cloud_area_fraction": 100.0,
+              "cloud_area_fraction_high": 25.8,
+              "cloud_area_fraction_low": 100.0,
+              "cloud_area_fraction_medium": 14.8,
+              "dew_point_temperature": 10.3,
+              "relative_humidity": 89.2,
+              "wind_from_direction": 201.9,
+              "wind_speed": 5.8
+            }
+          },
+          "next_12_hours": {
+            "summary": { "symbol_code": "cloudy" },
+            "details": {}
+          },
+          "next_6_hours": {
+            "summary": { "symbol_code": "cloudy" },
+            "details": {
+              "air_temperature_max": 12.1,
+              "air_temperature_min": 11.4,
+              "precipitation_amount": 0.3
+            }
+          }
+        }
+      },
+      {
+        "time": "2024-03-17T00:00:00Z",
+        "data": {
+          "instant": {
+            "details": {
+              "air_pressure_at_sea_level": 1012.1,
+              "air_temperature": 11.4,
+              "cloud_area_fraction": 99.2,
+              "cloud_area_fraction_high": 97.7,
+              "cloud_area_fraction_low": 78.1,
+              "cloud_area_fraction_medium": 0.8,
+              "dew_point_temperature": 9.9,
+              "relative_humidity": 90.0,
+              "wind_from_direction": 218.9,
+              "wind_speed": 4.8
+            }
+          },
+          "next_12_hours": {
+            "summary": { "symbol_code": "lightrainshowers_day" },
+            "details": {}
+          },
+          "next_6_hours": {
+            "summary": { "symbol_code": "cloudy" },
+            "details": {
+              "air_temperature_max": 11.6,
+              "air_temperature_min": 10.9,
+              "precipitation_amount": 0.1
+            }
+          }
+        }
+      },
+      {
+        "time": "2024-03-17T06:00:00Z",
+        "data": {
+          "instant": {
+            "details": {
+              "air_pressure_at_sea_level": 1010.1,
+              "air_temperature": 11.0,
+              "cloud_area_fraction": 100.0,
+              "cloud_area_fraction_high": 100.0,
+              "cloud_area_fraction_low": 100.0,
+              "cloud_area_fraction_medium": 36.7,
+              "dew_point_temperature": 10.2,
+              "relative_humidity": 93.8,
+              "wind_from_direction": 204.7,
+              "wind_speed": 4.5
+            }
+          },
+          "next_12_hours": {
+            "summary": { "symbol_code": "lightrainshowers_day" },
+            "details": {}
+          },
+          "next_6_hours": {
+            "summary": { "symbol_code": "lightrain" },
+            "details": {
+              "air_temperature_max": 15.6,
+              "air_temperature_min": 11.0,
+              "precipitation_amount": 0.9
+            }
+          }
+        }
+      },
+      {
+        "time": "2024-03-17T12:00:00Z",
+        "data": {
+          "instant": {
+            "details": {
+              "air_pressure_at_sea_level": 1009.6,
+              "air_temperature": 15.6,
+              "cloud_area_fraction": 21.1,
+              "cloud_area_fraction_high": 0.0,
+              "cloud_area_fraction_low": 6.2,
+              "cloud_area_fraction_medium": 14.8,
+              "dew_point_temperature": 9.6,
+              "relative_humidity": 67.2,
+              "wind_from_direction": 230.9,
+              "wind_speed": 7.3
+            }
+          },
+          "next_12_hours": {
+            "summary": { "symbol_code": "lightrainshowers_day" },
+            "details": {}
+          },
+          "next_6_hours": {
+            "summary": { "symbol_code": "lightrainshowers_day" },
+            "details": {
+              "air_temperature_max": 15.9,
+              "air_temperature_min": 12.3,
+              "precipitation_amount": 0.6
+            }
+          }
+        }
+      },
+      {
+        "time": "2024-03-17T18:00:00Z",
+        "data": {
+          "instant": {
+            "details": {
+              "air_pressure_at_sea_level": 1009.3,
+              "air_temperature": 12.3,
+              "cloud_area_fraction": 13.3,
+              "cloud_area_fraction_high": 0.0,
+              "cloud_area_fraction_low": 8.6,
+              "cloud_area_fraction_medium": 6.2,
+              "dew_point_temperature": 8.5,
+              "relative_humidity": 77.2,
+              "wind_from_direction": 231.1,
+              "wind_speed": 6.4
+            }
+          },
+          "next_12_hours": {
+            "summary": { "symbol_code": "fair_night" },
+            "details": {}
+          },
+          "next_6_hours": {
+            "summary": { "symbol_code": "fair_night" },
+            "details": {
+              "air_temperature_max": 12.3,
+              "air_temperature_min": 8.5,
+              "precipitation_amount": 0.0
+            }
+          }
+        }
+      },
+      {
+        "time": "2024-03-18T00:00:00Z",
+        "data": {
+          "instant": {
+            "details": {
+              "air_pressure_at_sea_level": 1010.8,
+              "air_temperature": 8.5,
+              "cloud_area_fraction": 0.8,
+              "cloud_area_fraction_high": 0.0,
+              "cloud_area_fraction_low": 0.0,
+              "cloud_area_fraction_medium": 0.0,
+              "dew_point_temperature": 7.1,
+              "relative_humidity": 91.2,
+              "wind_from_direction": 230.2,
+              "wind_speed": 4.9
+            }
+          },
+          "next_12_hours": {
+            "summary": { "symbol_code": "partlycloudy_day" },
+            "details": {}
+          },
+          "next_6_hours": {
+            "summary": { "symbol_code": "clearsky_night" },
+            "details": {
+              "air_temperature_max": 8.5,
+              "air_temperature_min": 7.0,
+              "precipitation_amount": 0.0
+            }
+          }
+        }
+      },
+      {
+        "time": "2024-03-18T06:00:00Z",
+        "data": {
+          "instant": {
+            "details": {
+              "air_pressure_at_sea_level": 1010.8,
+              "air_temperature": 7.1,
+              "cloud_area_fraction": 100.0,
+              "cloud_area_fraction_high": 100.0,
+              "cloud_area_fraction_low": 2.3,
+              "cloud_area_fraction_medium": 0.8,
+              "dew_point_temperature": 6.0,
+              "relative_humidity": 92.7,
+              "wind_from_direction": 229.0,
+              "wind_speed": 4.2
+            }
+          },
+          "next_12_hours": {
+            "summary": { "symbol_code": "partlycloudy_day" },
+            "details": {}
+          },
+          "next_6_hours": {
+            "summary": { "symbol_code": "cloudy" },
+            "details": {
+              "air_temperature_max": 13.8,
+              "air_temperature_min": 7.0,
+              "precipitation_amount": 0.0
+            }
+          }
+        }
+      },
+      {
+        "time": "2024-03-18T12:00:00Z",
+        "data": {
+          "instant": {
+            "details": {
+              "air_pressure_at_sea_level": 1011.0,
+              "air_temperature": 13.8,
+              "cloud_area_fraction": 38.3,
+              "cloud_area_fraction_high": 0.0,
+              "cloud_area_fraction_low": 36.7,
+              "cloud_area_fraction_medium": 2.3,
+              "dew_point_temperature": 5.5,
+              "relative_humidity": 57.1,
+              "wind_from_direction": 232.6,
+              "wind_speed": 6.6
+            }
+          },
+          "next_12_hours": {
+            "summary": { "symbol_code": "partlycloudy_day" },
+            "details": {}
+          },
+          "next_6_hours": {
+            "summary": { "symbol_code": "partlycloudy_day" },
+            "details": {
+              "air_temperature_max": 14.5,
+              "air_temperature_min": 11.0,
+              "precipitation_amount": 0.2
+            }
+          }
+        }
+      },
+      {
+        "time": "2024-03-18T18:00:00Z",
+        "data": {
+          "instant": {
+            "details": {
+              "air_pressure_at_sea_level": 1010.9,
+              "air_temperature": 11.0,
+              "cloud_area_fraction": 96.9,
+              "cloud_area_fraction_high": 91.4,
+              "cloud_area_fraction_low": 56.2,
+              "cloud_area_fraction_medium": 32.8,
+              "dew_point_temperature": 6.3,
+              "relative_humidity": 72.7,
+              "wind_from_direction": 221.5,
+              "wind_speed": 4.9
+            }
+          },
+          "next_12_hours": {
+            "summary": { "symbol_code": "cloudy" },
+            "details": {}
+          },
+          "next_6_hours": {
+            "summary": { "symbol_code": "cloudy" },
+            "details": {
+              "air_temperature_max": 11.2,
+              "air_temperature_min": 9.3,
+              "precipitation_amount": 0.1
+            }
+          }
+        }
+      },
+      {
+        "time": "2024-03-19T00:00:00Z",
+        "data": {
+          "instant": {
+            "details": {
+              "air_pressure_at_sea_level": 1010.7,
+              "air_temperature": 10.5,
+              "cloud_area_fraction": 100.0,
+              "cloud_area_fraction_high": 100.0,
+              "cloud_area_fraction_low": 81.2,
+              "cloud_area_fraction_medium": 95.3,
+              "dew_point_temperature": 8.9,
+              "relative_humidity": 90.4,
+              "wind_from_direction": 209.5,
+              "wind_speed": 4.9
+            }
+          },
+          "next_12_hours": {
+            "summary": { "symbol_code": "lightrain" },
+            "details": {}
+          },
+          "next_6_hours": {
+            "summary": { "symbol_code": "cloudy" },
+            "details": {
+              "air_temperature_max": 10.8,
+              "air_temperature_min": 10.3,
+              "precipitation_amount": 0.1
+            }
+          }
+        }
+      },
+      {
+        "time": "2024-03-19T06:00:00Z",
+        "data": {
+          "instant": {
+            "details": {
+              "air_pressure_at_sea_level": 1006.9,
+              "air_temperature": 10.5,
+              "cloud_area_fraction": 100.0,
+              "cloud_area_fraction_high": 93.7,
+              "cloud_area_fraction_low": 100.0,
+              "cloud_area_fraction_medium": 13.3,
+              "dew_point_temperature": 8.1,
+              "relative_humidity": 85.6,
+              "wind_from_direction": 200.4,
+              "wind_speed": 8.9
+            }
+          },
+          "next_12_hours": {
+            "summary": { "symbol_code": "lightrainshowers_day" },
+            "details": {}
+          },
+          "next_6_hours": {
+            "summary": { "symbol_code": "lightrain" },
+            "details": {
+              "air_temperature_max": 14.2,
+              "air_temperature_min": 10.5,
+              "precipitation_amount": 0.5
+            }
+          }
+        }
+      },
+      {
+        "time": "2024-03-19T12:00:00Z",
+        "data": {
+          "instant": {
+            "details": {
+              "air_pressure_at_sea_level": 1004.7,
+              "air_temperature": 14.1,
+              "cloud_area_fraction": 65.6,
+              "cloud_area_fraction_high": 0.0,
+              "cloud_area_fraction_low": 65.6,
+              "cloud_area_fraction_medium": 0.0,
+              "dew_point_temperature": 6.8,
+              "relative_humidity": 61.8,
+              "wind_from_direction": 224.4,
+              "wind_speed": 13.6
+            }
+          },
+          "next_12_hours": {
+            "summary": { "symbol_code": "partlycloudy_day" },
+            "details": {}
+          },
+          "next_6_hours": {
+            "summary": { "symbol_code": "partlycloudy_day" },
+            "details": {
+              "air_temperature_max": 14.5,
+              "air_temperature_min": 11.9,
+              "precipitation_amount": 0.1
+            }
+          }
+        }
+      },
+      {
+        "time": "2024-03-19T18:00:00Z",
+        "data": {
+          "instant": {
+            "details": {
+              "air_pressure_at_sea_level": 1004.6,
+              "air_temperature": 11.9,
+              "cloud_area_fraction": 18.0,
+              "cloud_area_fraction_high": 10.9,
+              "cloud_area_fraction_low": 7.0,
+              "cloud_area_fraction_medium": 0.8,
+              "dew_point_temperature": 6.1,
+              "relative_humidity": 67.6,
+              "wind_from_direction": 224.6,
+              "wind_speed": 10.9
+            }
+          },
+          "next_12_hours": {
+            "summary": { "symbol_code": "partlycloudy_night" },
+            "details": {}
+          },
+          "next_6_hours": {
+            "summary": { "symbol_code": "fair_night" },
+            "details": {
+              "air_temperature_max": 11.9,
+              "air_temperature_min": 8.9,
+              "precipitation_amount": 0.0
+            }
+          }
+        }
+      },
+      {
+        "time": "2024-03-20T00:00:00Z",
+        "data": {
+          "instant": {
+            "details": {
+              "air_pressure_at_sea_level": 1009.8,
+              "air_temperature": 8.9,
+              "cloud_area_fraction": 64.1,
+              "cloud_area_fraction_high": 4.7,
+              "cloud_area_fraction_low": 3.1,
+              "cloud_area_fraction_medium": 60.9,
+              "dew_point_temperature": 5.4,
+              "relative_humidity": 78.5,
+              "wind_from_direction": 233.4,
+              "wind_speed": 6.9
+            }
+          },
+          "next_12_hours": {
+            "summary": { "symbol_code": "lightrain" },
+            "details": {}
+          },
+          "next_6_hours": {
+            "summary": { "symbol_code": "partlycloudy_night" },
+            "details": {
+              "air_temperature_max": 8.9,
+              "air_temperature_min": 7.2,
+              "precipitation_amount": 0.0
+            }
+          }
+        }
+      },
+      {
+        "time": "2024-03-20T06:00:00Z",
+        "data": {
+          "instant": {
+            "details": {
+              "air_pressure_at_sea_level": 1012.0,
+              "air_temperature": 7.2,
+              "cloud_area_fraction": 100.0,
+              "cloud_area_fraction_high": 100.0,
+              "cloud_area_fraction_low": 10.9,
+              "cloud_area_fraction_medium": 38.3,
+              "dew_point_temperature": 5.1,
+              "relative_humidity": 85.4,
+              "wind_from_direction": 235.1,
+              "wind_speed": 3.1
+            }
+          },
+          "next_6_hours": {
+            "summary": { "symbol_code": "rain" },
+            "details": {
+              "air_temperature_max": 11.3,
+              "air_temperature_min": 7.2,
+              "precipitation_amount": 1.1
+            }
+          }
+        }
+      },
+      {
+        "time": "2024-03-20T12:00:00Z",
+        "data": {
+          "instant": {
+            "details": {
+              "air_pressure_at_sea_level": 1013.2,
+              "air_temperature": 10.4,
+              "cloud_area_fraction": 100.0,
+              "cloud_area_fraction_high": 100.0,
+              "cloud_area_fraction_low": 39.8,
+              "cloud_area_fraction_medium": 100.0,
+              "dew_point_temperature": 5.0,
+              "relative_humidity": 69.0,
+              "wind_from_direction": 281.8,
+              "wind_speed": 3.0
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/app/src/lib/open-weather-map/client.test.ts
+++ b/app/src/lib/open-weather-map/client.test.ts
@@ -18,6 +18,7 @@ import {
   OpenWeatherMapError,
   rawWeatherResponse,
 } from ".";
+import { GeoCodeData } from "../geocode";
 
 const { BAD_REQUEST, OK } = StatusCodes;
 
@@ -112,23 +113,33 @@ describe("OpenWeatherMapClient", () => {
     });
 
     const client = new OpenWeatherMapClient("testapikey", mockLogger);
-    const weather = await client.getWeather("metric", {
-      latitude: 0,
-      longitude: 0,
-    });
+    const weather = await client.getWeather(
+      "metric",
+      new GeoCodeData({
+        latitude: 0,
+        longitude: 0,
+      }),
+    );
 
     expect(weather.current.temp.temperature).toEqual(20);
     expect(weather.current.wind.speed).toEqual(2.57);
-    expect(weather.location).toEqual({ latitude: 0, longitude: 0 });
+    expect(weather.location).toEqual(
+      new GeoCodeData({ latitude: 0, longitude: 0 }),
+    );
 
-    const imperialWeather = await client.getWeather("imperial", {
-      latitude: 0,
-      longitude: 0,
-    });
+    const imperialWeather = await client.getWeather(
+      "imperial",
+      new GeoCodeData({
+        latitude: 0,
+        longitude: 0,
+      }),
+    );
 
     expect(imperialWeather.current.temp.temperature).toEqual(68);
     expect(weather.current.wind.speed).toEqual(2.57);
-    expect(weather.location).toEqual({ latitude: 0, longitude: 0 });
+    expect(weather.location).toEqual(
+      new GeoCodeData({ latitude: 0, longitude: 0 }),
+    );
 
     expect(mockAxios.history["get"]).toHaveLength(1);
     expect(ddbMock.commandCalls(PutCommand)).toHaveLength(1);
@@ -160,10 +171,13 @@ describe("OpenWeatherMapClient", () => {
     kvStore.set("openWeatherMap#1337#1337#metric", { rawWeather: mockResp });
 
     const client = new OpenWeatherMapClient("testapikey", mockLogger);
-    const weather = await client.getWeather("metric", {
-      latitude: 1337,
-      longitude: 1337,
-    });
+    const weather = await client.getWeather(
+      "metric",
+      new GeoCodeData({
+        latitude: 1337,
+        longitude: 1337,
+      }),
+    );
 
     expect(weather.current.temp.temperature).toEqual(1337);
 
@@ -176,17 +190,23 @@ describe("OpenWeatherMapClient", () => {
 
     mockAxios.onGet().reply(OK, mockResponse);
 
-    const weatherMetric = await client.getWeather("metric", {
-      latitude: 0,
-      longitude: 0,
-    });
+    const weatherMetric = await client.getWeather(
+      "metric",
+      new GeoCodeData({
+        latitude: 0,
+        longitude: 0,
+      }),
+    );
     expect(weatherMetric.current.temp.temperature).toEqual(20);
     expect(weatherMetric.current.wind.speed).toEqual(2.57);
 
-    const weatherImperial = await client.getWeather("imperial", {
-      latitude: 0,
-      longitude: 0,
-    });
+    const weatherImperial = await client.getWeather(
+      "imperial",
+      new GeoCodeData({
+        latitude: 0,
+        longitude: 0,
+      }),
+    );
     expect(weatherImperial.current.temp.temperature).toEqual(68); // 20C = 68F
     expect(weatherImperial.current.wind.speed).toBeCloseTo(5.75, 2); // 2.57 m/s = 5.75 mph
   });
@@ -205,10 +225,13 @@ describe("OpenWeatherMapClient", () => {
 
     mockAxios.onGet().reply(OK, mockResponse);
 
-    const weatherMetric = await client.getWeather("metric", {
-      latitude: 0,
-      longitude: 0,
-    });
+    const weatherMetric = await client.getWeather(
+      "metric",
+      new GeoCodeData({
+        latitude: 0,
+        longitude: 0,
+      }),
+    );
 
     expect(weatherMetric.current.time).toEqual(date);
   });
@@ -225,7 +248,10 @@ describe("OpenWeatherMapClient", () => {
     mockAxios.onGet().reply(OK, mockResponse);
 
     await expect(
-      client.getWeather("metric", { latitude: 0, longitude: 0 }),
+      client.getWeather(
+        "metric",
+        new GeoCodeData({ latitude: 0, longitude: 0 }),
+      ),
     ).rejects.toThrow(InvalidWindDirectionError);
   });
 
@@ -233,7 +259,10 @@ describe("OpenWeatherMapClient", () => {
     mockAxios.onGet().reply(BAD_REQUEST);
 
     await expect(
-      client.getWeather("metric", { latitude: 0, longitude: 0 }),
+      client.getWeather(
+        "metric",
+        new GeoCodeData({ latitude: 0, longitude: 0 }),
+      ),
     ).rejects.toThrow(OpenWeatherMapError);
   });
 });


### PR DESCRIPTION
We don't need to issue new queries for every nanometre on the planet. Having a resolution of a few metres is just fine.

This will reduce queries sent to our providers, and it'll improve the cache hit ratio a bit too.

Modify the tests to exercise this too, by returning full precision coordinates and expecting rounded ones.