### PR TITLE
gen: Use relative path for openapi-generator-cli schema

### DIFF
--- a/gen/geojs/openapitools.json
+++ b/gen/geojs/openapitools.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "./node_modules/@openapitools/openapi-generator-cli/config.schema.json",
+    "$schema": "../../node_modules/@openapitools/openapi-generator-cli/config.schema.json",
     "spaces": 2,
     "generator-cli": {
         "version": "7.2.0",

--- a/gen/met.no/openapitools.json
+++ b/gen/met.no/openapitools.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "./node_modules/@openapitools/openapi-generator-cli/config.schema.json",
+  "$schema": "../../node_modules/@openapitools/openapi-generator-cli/config.schema.json",
   "spaces": 2,
   "generator-cli": {
     "version": "7.2.0",
@@ -8,7 +8,6 @@
         "generatorName": "typescript-axios",
         "inputSpec": "schema.json",
         "output": ".",
-        "globalProperty": "debugOpenAPI,debugModels",
         "additionalProperties": {
           "npmName": "@internal/yr.no",
           "npmVersion": "0.0.1",

--- a/gen/nominatim/openapitools.json
+++ b/gen/nominatim/openapitools.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "./node_modules/@openapitools/openapi-generator-cli/config.schema.json",
+  "$schema": "../../node_modules/@openapitools/openapi-generator-cli/config.schema.json",
   "spaces": 2,
   "generator-cli": {
     "version": "7.2.0",


### PR DESCRIPTION
Since we're using workspaces, this gets hoisted to the root of the repository, so we need to find it up a level.

Also sneak in a change to drop some debug properties in met.no's config.