### PR TITLE
index/unknown: Fix redirections when using `/metno` handlers

### DIFF
--- a/app/src/handlers/index/index.ts
+++ b/app/src/handlers/index/index.ts
@@ -41,11 +41,12 @@ function handler(
     });
   }
 
-  // Redirect to /unknown if the client doesn't accept HTML
+  // Redirect to `:unknown` (relative to the current page) if the client doesn't
+  // accept HTML
   return Promise.resolve({
     statusCode: 302,
     headers: {
-      Location: "/:unknown",
+      Location: "./:unknown",
     },
     body: "",
   });

--- a/app/src/handlers/unknown/unknown.test.ts
+++ b/app/src/handlers/unknown/unknown.test.ts
@@ -52,7 +52,7 @@ describe("unknown handler", () => {
     await expect(unknownHandler(mockEvent, mockContext)).resolves.toEqual({
       statusCode: TEMPORARY_REDIRECT,
       headers: expect.objectContaining({
-        location: `/51.1/-96.1`,
+        location: "./51.1/-96.1",
       }),
     });
   });

--- a/app/src/handlers/unknown/unknown.ts
+++ b/app/src/handlers/unknown/unknown.ts
@@ -19,10 +19,11 @@ function handler(
 ): Promise<APIGatewayProxyResultV2> {
   const { latitude, longitude } = geoLocate.location;
 
+  // Redirect relative to the current page
   return Promise.resolve({
     statusCode: TEMPORARY_REDIRECT,
     headers: {
-      location: `/${latitude}/${longitude}`,
+      location: `./${latitude}/${longitude}`,
     },
   });
 }

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -8,27 +8,28 @@
   <body>
     <noscript>
       <!-- If JavaScript is disabled, redirect immediately -->
-      <meta http-equiv="refresh" content="0;url=/:unknown" />
+      <meta http-equiv="refresh" content="0;url=./:unknown" />
     </noscript>
     <script>
       function redirectBasedOnLocation() {
         if (!navigator.geolocation) {
           // If Geolocation API is not supported, redirect
-          window.location.href = "/:unknown";
+          window.location.replace("./:unknown");
           return;
         }
 
         navigator.geolocation.getCurrentPosition(
           function (position) {
-            // On successful geolocation, redirect to /lat/lon
             const latitude = position.coords.latitude;
             const longitude = position.coords.longitude;
-            window.location.href = `/${latitude}/${longitude}`;
+            window.location.replace(`./${latitude}/${longitude}`);
           },
           function (error) {
-            // On error or if geolocation permission is denied, redirect
+            // On error or if geolocation permission is denied, redirect to
+            // unknown handler, which will perform a lookup based on IP address
+            // (less accurate).
             console.error("Geolocation error:", error);
-            window.location.href = "/:unknown";
+            window.location.replace("./:unknown");
           },
         );
       }

--- a/serverless.yml
+++ b/serverless.yml
@@ -142,6 +142,9 @@ functions:
       - httpApi:
           path: /
           method: GET
+      - httpApi:
+          path: /metno
+          method: GET
 
   test:
     handler: ./app/src/handlers/test/index.testHandler
@@ -156,19 +159,8 @@ functions:
       - httpApi:
           path: "/:unknown"
           method: GET
-
-  reverseWeather:
-    handler: ./app/src/handlers/weather/index.reverseWeatherHandler
-    events:
       - httpApi:
-          path: /{lat}/{lon}
-          method: GET
-
-  weather:
-    handler: ./app/src/handlers/weather/index.weatherHandler
-    events:
-      - httpApi:
-          path: /{location}
+          path: "/metno/:unknown"
           method: GET
 
   reverseWeatherMetno:
@@ -183,6 +175,20 @@ functions:
     events:
       - httpApi:
           path: /metno/{location}
+          method: GET
+
+  reverseWeather:
+    handler: ./app/src/handlers/weather/index.reverseWeatherHandler
+    events:
+      - httpApi:
+          path: /{lat}/{lon}
+          method: GET
+
+  weather:
+    handler: ./app/src/handlers/weather/index.weatherHandler
+    events:
+      - httpApi:
+          path: /{location}
           method: GET
 
 resources:


### PR DESCRIPTION
When visiting the index or "unknown" (geolocate me please) handlers, we do the work and then redirect to a URL containing the lat/lon coordinates. These redirects didn't take into account our `/metno` prefix and would redirect to `/lat/lon` instead of `/metno/lat/lon`. Fix this by redirecting relative to the current URL instead of to `/<target>`.

Since we're using HTTP/JavaScript/HTML redirects, this is not testable currently, sadly. We would need e2e tests for this and we don't have those yet.

Use `window.location.replace()` instead of `window.location.href` to avoid creating a new history entry.

Rearrange the handlers in `serverless.yml` to make the more specific met.no handlers come first.