### PR TITLE
geocode: Drop double log

### DIFF
--- a/app/src/lib/geocode/middleware.ts
+++ b/app/src/lib/geocode/middleware.ts
@@ -117,8 +117,6 @@ export function geoCodeMiddleware<TResult>(): MiddlewareObj<
 
       const acceptLanguage = event.headers["accept-language"] ?? "en";
 
-      logger.debug("Geocoding", { location });
-
       try {
         const loc = await geoCode({ location, acceptLanguage }, logger);
 


### PR DESCRIPTION
We currently log "Geocoding" in both the middleware and the geocoder itself.
That results in two log lines for each geocoding request. Drop one of them.