### PR TITLE
Fix "unknown" redirects

### DIFF
--- a/app/src/handlers/index/index.ts
+++ b/app/src/handlers/index/index.ts
@@ -43,10 +43,11 @@ function handler(
 
   // Redirect to `:unknown` (relative to the current page) if the client doesn't
   // accept HTML
+  const rawPath = event.rawPath + (event.rawPath.endsWith("/") ? "" : "/");
   return Promise.resolve({
     statusCode: 302,
     headers: {
-      Location: "./:unknown",
+      Location: `${rawPath}:unknown`,
     },
     body: "",
   });

--- a/app/src/handlers/unknown/unknown.ts
+++ b/app/src/handlers/unknown/unknown.ts
@@ -14,16 +14,29 @@ import { GeoLocateContext, geoLocateMiddleware } from "@/lib/geolocate";
 const { TEMPORARY_REDIRECT } = StatusCodes;
 
 function handler(
-  _event: unknown,
+  event: APIGatewayProxyEventV2,
   { geoLocate }: GeoLocateContext,
 ): Promise<APIGatewayProxyResultV2> {
   const { latitude, longitude } = geoLocate.location;
 
   // Redirect relative to the current page
+
+  // Strip off any trailing slashes from the path and split it into parts
+  // (separated by slashes)
+  const rawPathParts = (
+    event.rawPath.endsWith("/") ? event.rawPath.slice(0, -1) : event.rawPath
+  ).split("/");
+
+  // Remove the last part of the path (":unknown")
+  rawPathParts.pop();
+
+  // And put it back together
+  const rawPath = rawPathParts.join("/");
+
   return Promise.resolve({
     statusCode: TEMPORARY_REDIRECT,
     headers: {
-      location: `./${latitude}/${longitude}`,
+      location: `${rawPath}/${latitude}/${longitude}`,
     },
   });
 }

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -8,13 +8,18 @@
   <body>
     <noscript>
       <!-- If JavaScript is disabled, redirect immediately -->
+      <!-- TOOD: This is wrong for `/metno` -->
       <meta http-equiv="refresh" content="0;url=./:unknown" />
     </noscript>
     <script>
       function redirectBasedOnLocation() {
+        const pathWithSlash =
+          window.location.pathname +
+          (window.location.pathname.endsWith("/") ? "" : "/");
+
         if (!navigator.geolocation) {
           // If Geolocation API is not supported, redirect
-          window.location.replace("./:unknown");
+          window.location.replace(`${pathWithSlash}:unknown`);
           return;
         }
 
@@ -22,14 +27,16 @@
           function (position) {
             const latitude = position.coords.latitude;
             const longitude = position.coords.longitude;
-            window.location.replace(`./${latitude}/${longitude}`);
+
+            window.location.replace(`${pathWithSlash}${latitude}/${longitude}`);
           },
+
           function (error) {
             // On error or if geolocation permission is denied, redirect to
             // unknown handler, which will perform a lookup based on IP address
             // (less accurate).
             console.error("Geolocation error:", error);
-            window.location.replace("./:unknown");
+            window.location.replace(`${pathWithSlash}:unknown`);
           },
         );
       }


### PR DESCRIPTION
The way we were trying to handle redirects for the "unknown" cases wasn't right when there was no trailing slash. Take this example: when the path is `/foo`, redirecting to `./bar` takes you to `/bar` instead of `/foo/bar`.

Instead we drop relative redirects and figure out the path ourselves.