### PR TITLE
geocode: Throw "no path" error when location is empty

### DIFF
--- a/app/src/lib/geocode/middleware.test.ts
+++ b/app/src/lib/geocode/middleware.test.ts
@@ -189,6 +189,18 @@ describe("Geocode Middleware", () => {
     );
   });
 
+  it("throws an error if called with empty location path parameter", async () => {
+    const mockEvent = mock<APIGatewayProxyEventV2>({
+      pathParameters: {
+        location: "",
+      },
+    });
+
+    await expect(middyHandler(mockEvent, geoLocateContext)).rejects.toThrow(
+      BadRequest,
+    );
+  });
+
   it("throws BadRequest if no path parameters", async () => {
     const mockEvent = mock<APIGatewayProxyEventV2>();
     delete mockEvent.pathParameters;

--- a/app/src/lib/geocode/middleware.ts
+++ b/app/src/lib/geocode/middleware.ts
@@ -111,8 +111,10 @@ export function geoCodeMiddleware<TResult>(): MiddlewareObj<
 
       const { location } = pathParameters;
 
-      if (location === undefined) {
-        throw new BadRequest("No city in path parameters");
+      if (location === undefined || location === "") {
+        throw new BadRequest(
+          "No location was given: try adding `/<some location>` to the URL",
+        );
       }
 
       const acceptLanguage = event.headers["accept-language"] ?? "en";


### PR DESCRIPTION
Previously we were just checking for `undefined`, but we should also check for empty strings because that's what API Gateway sends when the route is matched, e.g. for `/metno/` we get an empty `location` path paremeter matching the route `/metno/{location}`.

Also improve the message slightly to say what to do instead of basically "there was an error".