### PR TITLE
Add a feels like temperature to the output

### DIFF
--- a/app/src/handlers/weather/weather.test.ts
+++ b/app/src/handlers/weather/weather.test.ts
@@ -108,7 +108,7 @@ describe("reverseWeatherHandler", () => {
     const colouredString = formatString(
       "ansi",
       ({ greenBright }) =>
-        `☁️ 27.3°C, Wind ${greenBright("3.09")}–${greenBright("3.02")} m/s ↓\n`,
+        `☁️ 27.3(30.5)°C, Wind ${greenBright("3.09")}–${greenBright("3.02")} m/s ↓\n`,
     );
 
     await expect(
@@ -199,7 +199,7 @@ describe("weatherHandler", () => {
     const colouredString = formatString(
       "ansi",
       ({ greenBright }) =>
-        `☁️ 27.3°C, Wind ${greenBright("3.09")}–${greenBright("3.02")} m/s ↓\n`,
+        `☁️ 27.3(30.5)°C, Wind ${greenBright("3.09")}–${greenBright("3.02")} m/s ↓\n`,
     );
 
     await expect(weatherHandler(mockEvent, mockContext)).resolves.toEqual({
@@ -226,7 +226,7 @@ describe("weatherHandler", () => {
     const colouredString = formatString(
       "ansi",
       ({ greenBright }) =>
-        `☁️ 81.1°F, Wind ${greenBright("6.91")}–${greenBright("6.76")} mph ↓\n`,
+        `☁️ 81.1(86.9)°F, Wind ${greenBright("6.91")}–${greenBright("6.76")} mph ↓\n`,
     );
 
     const mockEventImperial = mockEvent;

--- a/app/src/lib/metno/client.test.ts
+++ b/app/src/lib/metno/client.test.ts
@@ -123,7 +123,7 @@ describe("met.no client happy paths", () => {
     expect(weather.current.temp.temperature).toBe(44.6); // 7.0°C  = 44.6°F
     expect(weather.current.wind.speed).toBe(4.47388); // 2.0 m/s = 4.47388 mph
 
-    expect(weather.hourly[0]?.temp.temperature).toBe(44.42);
+    expect(weather.hourly[0]?.temp.temperature).toBe(44.4);
     expect(weather.daily[0]?.temp.max.temperature).toBe(59);
 
     expect(kvStore.size).toBe(1);

--- a/app/src/lib/weather/temperature.test.ts
+++ b/app/src/lib/weather/temperature.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "@jest/globals";
 
-import { DegreesCelsius, DegreesFahrenheit } from ".";
+import {
+  DegreesCelsius,
+  DegreesFahrenheit,
+  WindSpeedMetresPerSecond,
+  WindSpeedMilesPerHour,
+} from ".";
 
 describe("Temperature Conversion", () => {
   it("DegreesCelsius to DegreesFahrenheit", () => {
@@ -9,26 +14,10 @@ describe("Temperature Conversion", () => {
     expect(tempF.temperature).toBeCloseTo(212);
   });
 
-  it("DegreesCelsius Feels Like", () => {
-    const tempC = new DegreesCelsius(32);
-
-    const feelsLike = tempC.feelsLike(85);
-
-    expect(feelsLike.temperature).toBeCloseTo(46.58);
-  });
-
   it("DegreesFahrenheit to DegreesCelsius", () => {
     const tempF = new DegreesFahrenheit(212);
     const tempC = tempF.toDegreesCelsius();
     expect(tempC.temperature).toBeCloseTo(100);
-  });
-
-  it("DegreesFahrenheit Feels Like", () => {
-    const tempF = new DegreesFahrenheit(89.6);
-
-    const feelsLike = tempF.feelsLike(85);
-
-    expect(feelsLike.temperature).toBeCloseTo(115.85);
   });
 
   it("DegreesCelsius toString", () => {
@@ -75,6 +64,92 @@ describe("Temperature Conversion", () => {
 
   it("converts to JSON", () => {
     const tempC = new DegreesCelsius(100);
-    expect(JSON.stringify(tempC)).toBe('{"value":100,"unit":"°C"}');
+    expect(JSON.stringify(tempC)).toBe('{"temperature":100,"unit":"°C"}');
   });
+});
+
+describe("Feels Like Temperature", () => {
+  it.each<{
+    temperature: number;
+    humidity: number;
+    windSpeed: number;
+    expected: number;
+  }>([
+    {
+      // Using the heat index formula
+      temperature: 34,
+      humidity: 85,
+      windSpeed: Number.MAX_SAFE_INTEGER, // gets ignored
+      expected: 55.2,
+    },
+    {
+      // Using the wind chill formula
+      temperature: -10,
+      humidity: Number.MIN_SAFE_INTEGER, // gets ignored
+      windSpeed: 2.77778, // 10 km/h
+      expected: -15.3,
+    },
+    {
+      // In between 10 and 27°C, the temperature is just passed through, sadly
+      temperature: 20,
+      humidity: 50,
+      windSpeed: 10,
+      expected: 20,
+    },
+  ])(
+    "DegreesCelsius temp $temperature humidity $humidity windSpeed $windSpeed feels like $expected",
+    ({ temperature, humidity, windSpeed, expected }) => {
+      const tempC = new DegreesCelsius(temperature);
+
+      const windSpeedMPS = new WindSpeedMetresPerSecond(
+        windSpeed,
+        windSpeed,
+        "N",
+      );
+
+      const feelsLike = tempC.feelsLike(humidity, windSpeedMPS);
+
+      expect(feelsLike.temperature).toBeCloseTo(expected);
+    },
+  );
+
+  it.each<{
+    temperature: number;
+    humidity: number;
+    windSpeed: number;
+    expected: number;
+  }>([
+    {
+      // Using the heat index formula
+      temperature: 85,
+      humidity: 50,
+      windSpeed: Number.NEGATIVE_INFINITY, // gets ignored
+      expected: 86.5,
+    },
+    {
+      // Using the wind chill formula
+      temperature: 32,
+      humidity: Number.POSITIVE_INFINITY, // gets ignored
+      windSpeed: 10, // mph
+      expected: 23.7,
+    },
+    {
+      // In between 50 and 80.5°F, the temperature is just passed through, sadly
+      temperature: 70,
+      humidity: 50,
+      windSpeed: 10,
+      expected: 70,
+    },
+  ])(
+    "DegreesFahrenheit temp $temperature humidity $humidity windSpeed $windSpeed feels like $expected",
+    ({ temperature, humidity, windSpeed, expected }) => {
+      const tempC = new DegreesFahrenheit(temperature);
+
+      const windSpeedMPS = new WindSpeedMilesPerHour(windSpeed, windSpeed, "N");
+
+      const feelsLike = tempC.feelsLike(humidity, windSpeedMPS);
+
+      expect(feelsLike.temperature).toBeCloseTo(expected);
+    },
+  );
 });

--- a/app/src/lib/weather/temperature.ts
+++ b/app/src/lib/weather/temperature.ts
@@ -1,3 +1,5 @@
+import { WindSpeedMetresPerSecond, WindSpeedMilesPerHour } from "./wind";
+
 export type Units = "metric" | "imperial";
 
 export function isUnits(u: string): u is Units {
@@ -21,22 +23,41 @@ type feelsLikeConstants = {
   [K in Index]: number;
 };
 
+export interface Temperature {
+  temperature: number;
+  unit: string;
+}
+
+export function TemperatureToDegrees({
+  temperature,
+  unit,
+}: Temperature): BaseDegreesWithFeelsLike {
+  switch (unit) {
+    case "°C":
+      return new DegreesCelsius(temperature);
+    case "°F":
+      return new DegreesFahrenheit(temperature);
+    default:
+      throw new Error(`Unknown unit: ${unit}`);
+  }
+}
+
 abstract class BaseDegrees {
-  constructor(public readonly temperature: number) {}
+  constructor(protected readonly temp: number) {}
 
   abstract unit: string;
 
-  private get roundedToOneDP(): number {
-    return Math.round(this.temperature * 10) / 10;
+  public get temperature(): number {
+    return Math.round(this.temp * 10) / 10;
   }
 
   toString(): string {
-    return `${this.roundedToOneDP}${this.unit}`;
+    return `${this.temperature}${this.unit}`;
   }
 
-  toJSON(): { value: number; unit: string } {
+  toJSON(): Temperature {
     return {
-      value: this.roundedToOneDP,
+      temperature: this.temperature,
       unit: this.unit,
     };
   }
@@ -48,22 +69,25 @@ abstract class BaseDegreesWithFeelsLike extends BaseDegrees {
   // TODO: OpenWeatherMap actually provides a `feels_like` property itself, but
   // met.no does not; it would be better if we could use that when the provider
   // has it, rather than always calculating it ourselves.
-  abstract feelsLike(humidity: number): BaseDegrees;
+  abstract feelsLike(
+    humidity: number,
+    windSpeed: { speed: number },
+  ): BaseDegrees;
 
-  protected calculateFeelsLike(humidity: number) {
+  protected heatIndex(humidity: number) {
     const c = this.feelsLikeConstants;
 
     // https://en.wikipedia.org/wiki/Heat_index#Formula
     return (
       c[1] +
-      c[2] * this.temperature +
+      c[2] * this.temp +
       c[3] * humidity +
-      c[4] * this.temperature * humidity +
-      c[5] * this.temperature * this.temperature +
+      c[4] * this.temp * humidity +
+      c[5] * this.temp * this.temp +
       c[6] * humidity * humidity +
-      c[7] * this.temperature * this.temperature * humidity +
-      c[8] * this.temperature * humidity * humidity +
-      c[9] * this.temperature * this.temperature * humidity * humidity
+      c[7] * this.temp * this.temp * humidity +
+      c[8] * this.temp * humidity * humidity +
+      c[9] * this.temp * this.temp * humidity * humidity
     );
   }
 }
@@ -83,13 +107,40 @@ export class DegreesCelsius extends BaseDegreesWithFeelsLike {
   };
 
   toDegreesFahrenheit(): DegreesFahrenheit {
-    return new DegreesFahrenheit((this.temperature * 9) / 5 + 32); // 1°C × 9/5 + 32 = 33.8°F
+    return new DegreesFahrenheit((this.temp * 9) / 5 + 32); // 1°C × 9/5 + 32 = 33.8°F
+  }
+
+  private windChill(windSpeed: WindSpeedMetresPerSecond): number {
+    // Convert m/s to km/h
+    const speed = windSpeed.speed * 3.6;
+
+    // https://en.wikipedia.org/wiki/Wind_chill#North_American_and_United_Kingdom_wind_chill_index
+    return (
+      13.12 +
+      0.6215 * this.temp -
+      11.37 * Math.pow(speed, 0.16) +
+      0.3965 * this.temp * Math.pow(speed, 0.16)
+    );
   }
 
   // TODO: It would be better if `feelsLike` didn't return a `DegreesCelsius` so
   // it itself didn't have a `feelsLike` method.
-  public feelsLike(humidity: number): DegreesCelsius {
-    return new DegreesCelsius(this.calculateFeelsLike(humidity));
+  public feelsLike(
+    humidity: number,
+    windSpeed: WindSpeedMetresPerSecond,
+  ): DegreesCelsius {
+    // Use heat index if temperature is above 26°C and humidity is above or equal to 40%
+    if (this.temp > 26 && humidity >= 40) {
+      return new DegreesCelsius(this.heatIndex(humidity));
+    }
+
+    // Use wind chill if temperature is below 10°C and wind speed is above
+    // 1.34m/s (4.8km/h)
+    if (this.temp < 10 && windSpeed.speed > 1.34) {
+      return new DegreesCelsius(this.windChill(windSpeed));
+    }
+
+    return this;
   }
 
   static is(value: unknown): value is DegreesCelsius {
@@ -111,14 +162,41 @@ export class DegreesFahrenheit extends BaseDegreesWithFeelsLike {
     9: -0.00000199,
   };
 
+  private windChill(windSpeed: WindSpeedMilesPerHour): number {
+    const speed = windSpeed.speed;
+
+    // https://en.wikipedia.org/wiki/Wind_chill#North_American_and_United_Kingdom_wind_chill_index
+    return (
+      35.74 +
+      0.6215 * this.temp -
+      35.75 * Math.pow(speed, 0.16) +
+      0.4275 * this.temp * Math.pow(speed, 0.16)
+    );
+  }
+
   // TODO: It would be better if `feelsLike` didn't return a `DegreesFahrenheit`
   // so it itself didn't have a `feelsLike` method.
-  public feelsLike(humidity: number): DegreesFahrenheit {
-    return new DegreesFahrenheit(this.calculateFeelsLike(humidity));
+  public feelsLike(
+    humidity: number,
+    windSpeed: WindSpeedMilesPerHour,
+  ): DegreesFahrenheit {
+    // Use heat index if temperature is above 80.5°F and humidity is greater
+    // than or equal to 40%
+    if (this.temp > 80.5 && humidity >= 40) {
+      return new DegreesFahrenheit(this.heatIndex(humidity));
+    }
+
+    // Use wind chill if temperature is below 50°F and wind speed is above 3mph
+    if (this.temp < 50 && humidity > 3) {
+      return new DegreesFahrenheit(this.windChill(windSpeed));
+    }
+
+    // Otherwise, return the same temperature
+    return this;
   }
 
   toDegreesCelsius(): DegreesCelsius {
-    return new DegreesCelsius(((this.temperature - 32) * 5) / 9);
+    return new DegreesCelsius(((this.temp - 32) * 5) / 9);
   }
 
   static is(value: unknown): value is DegreesFahrenheit {

--- a/app/src/lib/weather/templates/html/measurement.liquid
+++ b/app/src/lib/weather/templates/html/measurement.liquid
@@ -1,0 +1,15 @@
+{%  assign feels_like = measurement.temp | feels_like: measurement.humidity, measurement.wind.speed -%}
+<table>
+    <tr>
+        <td style="font-family: monospace; white-space: pre;">{{ measurement.weather[0].art.html }}</td>
+        <td>
+            <h2>{{ date }}</h2>
+            <p>Temperature: {{ measurement.temp }}</p>
+            <p>Feels like: {{ feels_like }}{{ measurement.temp.unit }}</p>
+            <p>Wind: {{ measurement.wind.HTMLString }}</p>
+            <p>Pressure: {{ measurement.pressure }} hPa</p>
+            <p>Humidity: {{ measurement.humidity }}%</p>
+            <p>Clouds: {{ measurement.clouds }}%</p>
+        </td>
+    </tr>
+</table>

--- a/app/src/lib/weather/templates/html/weather.liquid
+++ b/app/src/lib/weather/templates/html/weather.liquid
@@ -8,33 +8,17 @@
   </head>
   <body>
     <p>Weather report: {{ location.label }}</p>
-    <h2>Now</h2>
+    {% render './measurement', measurement: current, date: 'Now' %}
     <p>{{ current.weather[0].art.emoji }} {{ current.temp }}, Wind {{ current.wind.HTMLString }}</p>
 
     <h2>Hourly Forecast</h2>
-    <ul>
-      {% for hour in hourly %}
-      <li>
-        <strong>{{ hour.time | date: "%H:%M" }}</strong>:
-        {{ hour.weather[0].art.emoji }}
-        {{ hour.temp }}
-        Wind {{ hour.wind.HTMLString }}
-      </li>
-      {% endfor %}
-    </ul>
+    {% for hour in hourly %}
+      {% render './measurement', measurement: hour, date: hour.time %}
+    {% endfor %}
 
     <h2>Daily Forecast</h2>
-    <ul>
-      {% for day in daily %}
-      <li>
-        <strong>{{ day.time | date: "%Y-%m-%d" }}</strong>:
-        Day {{ day.temp.day }}
-        Min {{ day.temp.min }}
-        Max {{ day.temp.max }}
-        {{ day.weather[0].art.emoji }}
-        Wind {{ day.wind.HTMLString }}
-      </li>
-      {% endfor %}
-    </ul>
+    {% for day in daily %}
+      {% render './measurement', measurement: day, date: day.time | date: "%Y-%m-%d" %}
+    {% endfor %}
   </body>
 </html>

--- a/app/src/lib/weather/templates/text/weather.liquid
+++ b/app/src/lib/weather/templates/text/weather.liquid
@@ -1,1 +1,2 @@
-{{ current.weather[0].art.emoji }} {{ current.temp }}, Wind {% if opts.colour %}{{ current.wind.ANSIString }}{% else %}{{ current.wind }}{% endif %}
+{%  assign feels_like = current.temp | feels_like: current.humidity, current.wind.speed -%}
+{{ current.weather[0].art.emoji }} {{ current.temp.temperature }}{% if current.temp.temperature != feels_like %}({{ feels_like }}){% endif %}{{ current.temp.unit }}, Wind {% if opts.colour %}{{ current.wind.ANSIString }}{% else %}{{ current.wind }}{% endif %}

--- a/app/src/lib/weather/weather.test.ts
+++ b/app/src/lib/weather/weather.test.ts
@@ -17,25 +17,31 @@ const location = new GeoCodeData({
   longitude: -96.1,
 });
 
-const now: CurrentMeasurement<"metric"> = {
-  clouds: 75,
-  humidity: 0.5,
-  pressure: 1000,
-  temp: new DegreesCelsius(20),
-  time: new Date(0),
-  weather: [
-    WeatherConditions[212], // heavy thunderstorm
-  ],
-  wind: new WindSpeedMetresPerSecond(5, 10, "S"),
-};
-
-const weather = new Weather(location, now, [], []);
-
 describe("render", () => {
-  it("should render the weather", async () => {
+  it.each<{
+    temperature: number;
+    expected: string;
+  }>([
+    { temperature: 15, expected: "15°C, Wind 5–10 m/s ↓" },
+    { temperature: 28, expected: "28(28.4)°C, Wind 5–10 m/s ↓" },
+  ])("should render the weather", async ({ temperature, expected }) => {
+    const now = {
+      clouds: 75,
+      humidity: 50,
+      pressure: 1000,
+      temp: new DegreesCelsius(temperature),
+      time: new Date(0),
+      weather: [
+        WeatherConditions[212], // heavy thunderstorm
+      ],
+      wind: new WindSpeedMetresPerSecond(5, 10, "S"),
+    } as const satisfies CurrentMeasurement<"metric">;
+
+    const weather = new Weather(location, now, [], []);
+
     const rendered = await weather.render["text/plain"]({ colour: false });
 
     // TODO: I can't compare the emoji at the start for some reason, figure it out
-    expect(rendered).toContain("20°C, Wind 5–10 m/s ↓");
+    expect(rendered).toContain(expected);
   });
 });


### PR DESCRIPTION
We do this via a liquid.js filter. This lets us write

```
{{ temperature | feels_like: humidity, windSpeed }}
```

in our templates.

A small complication results in the output. We show this as

```
10.0(10.2)°C
```

where the first number is the actual temperature and the second number is the feels like temperature. But if the feels like is the same as the actual temperature, then we omit the second number. This means we can't just use `toString` on a temperature object any more. (Feels like can't just be a property either, since it requires humidity and wind speed to calculate.)

So now we give the temperature to the rest of the application after rounding, always, and it can decide when to add the units. This might be revisted later to make it be more ergonomic. Or it might be fine - we'll see.