### PR TITLE
metno: Round pressure/humidity/cloud cover to two decimal places

### DIFF
--- a/app/src/lib/metno/convert.test.ts
+++ b/app/src/lib/metno/convert.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "@jest/globals";
 import { DegreesCelsius } from "@/lib/weather";
 import { ForecastTimeStep } from "@internal/met.no";
 
-import { convertCurrent } from "./convert";
+import { convertCurrent, convertDaily } from "./convert";
 
 describe("convertCurrent", () => {
   const mockForecastTimeStep = {
@@ -66,5 +66,141 @@ describe("convertCurrent", () => {
     expect(() => convertCurrent(step as ForecastTimeStep)).toThrowError(
       expect.objectContaining({ property: "symbol_code" }),
     );
+  });
+});
+
+describe("covertDaily", () => {
+  const date = new Date("2022-02-22T22:22:22Z");
+
+  it("averages fields for the day", () => {
+    const mockForecastTimeSteps = [
+      {
+        time: "2022-02-22T22:22:22Z",
+        data: {
+          instant: {
+            details: {
+              air_pressure_at_sea_level: 1000,
+              air_temperature: 10.0,
+              cloud_area_fraction: 0.0,
+              relative_humidity: 0.5,
+              wind_from_direction: 0.0,
+              wind_speed: 0.0,
+              wind_speed_of_gust: 0.0,
+            },
+          },
+          next_1_hours: {
+            summary: {
+              symbol_code: "clearsky_day",
+            },
+            details: {},
+          },
+        },
+      },
+      {
+        time: "2022-02-22T23:22:22Z",
+        data: {
+          instant: {
+            details: {
+              air_pressure_at_sea_level: 500,
+              air_temperature: 10.0,
+              cloud_area_fraction: 0.5,
+              relative_humidity: 1,
+              wind_from_direction: 0.0,
+              wind_speed: 0.0,
+              wind_speed_of_gust: 0.0,
+            },
+          },
+          next_1_hours: {
+            summary: {
+              symbol_code: "clearsky_day",
+            },
+            details: {},
+          },
+        },
+      },
+    ] as const satisfies ForecastTimeStep[];
+
+    const daily = convertDaily(date, mockForecastTimeSteps);
+
+    expect(daily.clouds).toBe(0.25);
+    expect(daily.pressure).toBe(750);
+    expect(daily.humidity).toBe(0.75);
+  });
+
+  it("rounds averages to two decimal places", () => {
+    const mockForecastTimeSteps = [
+      {
+        time: "2022-02-22T21:22:22Z",
+        data: {
+          instant: {
+            details: {
+              air_pressure_at_sea_level: 333,
+              air_temperature: 10.0,
+              cloud_area_fraction: 0.3,
+              relative_humidity: 0.3,
+              wind_from_direction: 0.0,
+              wind_speed: 0.0,
+              wind_speed_of_gust: 0.0,
+            },
+          },
+          next_1_hours: {
+            summary: {
+              symbol_code: "clearsky_day",
+            },
+            details: {},
+          },
+        },
+      },
+      {
+        time: "2022-02-22T22:22:22Z",
+        data: {
+          instant: {
+            details: {
+              air_pressure_at_sea_level: 333,
+              air_temperature: 10.0,
+              cloud_area_fraction: 0.3,
+              relative_humidity: 0.4,
+              wind_from_direction: 0.0,
+              wind_speed: 0.0,
+              wind_speed_of_gust: 0.0,
+            },
+          },
+          next_1_hours: {
+            summary: {
+              symbol_code: "clearsky_day",
+            },
+            details: {},
+          },
+        },
+      },
+      {
+        time: "2022-02-22T23:22:22Z",
+        data: {
+          instant: {
+            details: {
+              air_pressure_at_sea_level: 334,
+              air_temperature: 10.0,
+              cloud_area_fraction: 0.4,
+              relative_humidity: 0.3,
+              wind_from_direction: 0.0,
+              wind_speed: 0.0,
+              wind_speed_of_gust: 0.0,
+            },
+          },
+          next_1_hours: {
+            summary: {
+              symbol_code: "clearsky_day",
+            },
+            details: {},
+          },
+        },
+      },
+    ] as const satisfies ForecastTimeStep[];
+
+    const daily = convertDaily(date, mockForecastTimeSteps);
+
+    expect(daily.pressure).toBe(333.33);
+    expect(daily.clouds).toBe(0.33);
+    expect(daily.humidity).toBe(0.33);
   });
 });

--- a/app/src/lib/metno/convert.ts
+++ b/app/src/lib/metno/convert.ts
@@ -9,6 +9,7 @@ import {
   isDegree,
   WindDirection,
 } from "@/lib/weather";
+import { toTwoDP } from "@/lib/util";
 
 import { MetNoMissingPropertyError } from "./client";
 import { WeatherConditions } from "./weather-conditions";
@@ -147,9 +148,9 @@ export function convertDaily(
 
   return {
     time: date,
-    pressure: pressure / steps.length,
-    humidity: humidity / steps.length,
-    clouds: cloudCover / steps.length,
+    pressure: toTwoDP(pressure / steps.length),
+    humidity: toTwoDP(humidity / steps.length),
+    clouds: toTwoDP(cloudCover / steps.length),
     temp: {
       min: new DegreesCelsius(minTemp),
       max: new DegreesCelsius(maxTemp),

--- a/app/src/lib/util/index.ts
+++ b/app/src/lib/util/index.ts
@@ -1,0 +1,1 @@
+export * from "./maths";

--- a/app/src/lib/util/maths.test.ts
+++ b/app/src/lib/util/maths.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "@jest/globals";
+
+import { toOneDP, toTwoDP } from ".";
+
+describe("maths utitlies", () => {
+  it("rounds to 1 decimal place", () => {
+    expect(toOneDP(1.2345)).toBe(1.2);
+  });
+
+  it("rounds to 2 decimal places", () => {
+    expect(toTwoDP(1.2345)).toBe(1.23);
+  });
+
+  it("leaves integers unchanged", () => {
+    expect(toOneDP(1)).toBe(1);
+    expect(toTwoDP(1)).toBe(1);
+  });
+});

--- a/app/src/lib/util/maths.ts
+++ b/app/src/lib/util/maths.ts
@@ -1,0 +1,23 @@
+function round(precision: number): (value: number) => number {
+  const factor = 10 ** precision;
+
+  return (value: number) => Math.round(value * factor) / factor;
+}
+
+/**
+ * Round a number to one decimal place.
+ *
+ * @param value The number to round.
+ *
+ * @returns The number rounded to one decimal place.
+ */
+export const toOneDP = round(1);
+
+/**
+ * Round a number to two decimal places.
+ *
+ * @param value The number to round.
+ *
+ * @returns The number rounded to two decimal places.
+ */
+export const toTwoDP = round(2);

--- a/app/src/lib/weather/temperature.ts
+++ b/app/src/lib/weather/temperature.ts
@@ -1,3 +1,5 @@
+import { toOneDP } from "@/lib/util";
+
 import { WindSpeedMetresPerSecond, WindSpeedMilesPerHour } from "./wind";
 
 export type Units = "metric" | "imperial";
@@ -48,7 +50,7 @@ abstract class BaseDegrees {
   abstract unit: string;
 
   public get temperature(): number {
-    return Math.round(this.temp * 10) / 10;
+    return toOneDP(this.temp);
   }
 
   toString(): string {

--- a/app/src/lib/weather/wind.ts
+++ b/app/src/lib/weather/wind.ts
@@ -1,3 +1,5 @@
+import { toTwoDP } from "@/lib/util";
+
 import { ansi, html, ThemeColours } from "./colours";
 import { Units } from ".";
 
@@ -200,7 +202,7 @@ abstract class SingleWindSpeed {
   }
 
   private get toTwoDP(): number {
-    return Math.round(this.speed * 100) / 100;
+    return toTwoDP(this.speed);
   }
 
   get ANSIString(): string {


### PR DESCRIPTION
We average these when showing daily summaries, which means we can end up with a lot of decimal places. 2DP should be plenty.

Since we do rounding in a few places, start a `util` library so we don't end up writing the same code many times and put the rounding functions in there.