### PR TITLE
layout: Lay days out on one row, make colour names lowercase

### DIFF
--- a/app/src/handlers/weather/weather.test.ts
+++ b/app/src/handlers/weather/weather.test.ts
@@ -107,8 +107,8 @@ describe("reverseWeatherHandler", () => {
 
     const colouredString = formatString(
       "ansi",
-      ({ greenBright }) =>
-        `☁️ 27.3(30.5)°C, Wind ${greenBright("3.09")}–${greenBright("3.02")} m/s ↓\n`,
+      ({ greenbright }) =>
+        `☁️ 27.3(30.5)°C, Wind ${greenbright("3.09")}–${greenbright("3.02")} m/s ↓\n`,
     );
 
     await expect(
@@ -198,8 +198,8 @@ describe("weatherHandler", () => {
 
     const colouredString = formatString(
       "ansi",
-      ({ greenBright }) =>
-        `☁️ 27.3(30.5)°C, Wind ${greenBright("3.09")}–${greenBright("3.02")} m/s ↓\n`,
+      ({ greenbright }) =>
+        `☁️ 27.3(30.5)°C, Wind ${greenbright("3.09")}–${greenbright("3.02")} m/s ↓\n`,
     );
 
     await expect(weatherHandler(mockEvent, mockContext)).resolves.toEqual({
@@ -225,8 +225,8 @@ describe("weatherHandler", () => {
 
     const colouredString = formatString(
       "ansi",
-      ({ greenBright }) =>
-        `☁️ 81.1(86.9)°F, Wind ${greenBright("6.91")}–${greenBright("6.76")} mph ↓\n`,
+      ({ greenbright }) =>
+        `☁️ 81.1(86.9)°F, Wind ${greenbright("6.91")}–${greenbright("6.76")} mph ↓\n`,
     );
 
     const mockEventImperial = mockEvent;

--- a/app/src/lib/weather/colours.test.ts
+++ b/app/src/lib/weather/colours.test.ts
@@ -22,9 +22,9 @@ describe("Colour Formatter", () => {
 
   it("formats using formatMany", () => {
     const artTemplates = formatMany(
-      ({ grey, yellowBright }: RenderColours) => ({
+      ({ grey, yellowbright }: RenderColours) => ({
         goodbye: grey("goodbye"),
-        hello: yellowBright("hello"),
+        hello: yellowbright("hello"),
       }),
     );
 
@@ -34,7 +34,7 @@ describe("Colour Formatter", () => {
     });
 
     expect(artTemplates.hello).toEqual({
-      html: '<span class="yellowBright">hello</span>',
+      html: '<span class="yellowbright">hello</span>',
       ansi: chalk.yellowBright("hello"),
     });
   });

--- a/app/src/lib/weather/colours.ts
+++ b/app/src/lib/weather/colours.ts
@@ -14,18 +14,18 @@ interface ColourMappings {
 
 const colourMappings = {
   green: { ansi: chalk.green, html: cssString("green") },
-  greenBright: { ansi: chalk.greenBright, html: cssString("greenBright") },
+  greenbright: { ansi: chalk.greenBright, html: cssString("greenbright") },
   yellow: { ansi: chalk.yellow, html: cssString("yellow") },
-  yellowBright: { ansi: chalk.yellowBright, html: cssString("yellowBright") },
-  redBright: { ansi: chalk.redBright, html: cssString("redBright") },
+  yellowbright: { ansi: chalk.yellowBright, html: cssString("yellowbright") },
+  redbright: { ansi: chalk.redBright, html: cssString("redbright") },
   red: { ansi: chalk.red, html: cssString("red") },
   white: { ansi: chalk.white, html: cssString("white") },
   grey: { ansi: chalk.ansi256(251), html: cssString("grey") },
-  lightGrey: { ansi: chalk.hex("#C0C0C0"), html: cssString("lightgrey") },
-  darkGrey: { ansi: chalk.bold.hex("#808080"), html: cssString("darkgrey") },
+  lightgrey: { ansi: chalk.hex("#C0C0C0"), html: cssString("lightgrey") },
+  darkgrey: { ansi: chalk.bold.hex("#808080"), html: cssString("darkgrey") },
   blue: { ansi: chalk.blue, html: cssString("blue") },
   lightBlue: { ansi: chalk.bold.hex("#ADD8E6"), html: cssString("lightblue") },
-  whiteBright: { ansi: chalk.whiteBright, html: cssString("whiteBright") },
+  whitebright: { ansi: chalk.whiteBright, html: cssString("whitebright") },
   black: { ansi: chalk.black, html: cssString("black") },
 } satisfies ColourMappings;
 

--- a/app/src/lib/weather/templates/html/measurement.liquid
+++ b/app/src/lib/weather/templates/html/measurement.liquid
@@ -1,13 +1,11 @@
 {% assign feels_like = measurement.temp | feels_like: measurement.humidity, measurement.wind.speed -%}
 
 <div>
-<p>{{ date | date: "%H:%M" }}</p>
-<div style="font-family: monospace; white-space: pre;">{{ measurement.weather[0].art.html }}</div>
-<pre>
-🌡️ {{ measurement.temp.temperature }}{% if measurement.temp.temperature != feels_like %}({{ feels_like }}){% endif %}{{ measurement.temp.unit }}
+    <p>{{ date | date: "%H:%M" }}</p>
+    <div style="font-family: monospace; white-space: pre;">{{ measurement.weather[0].art.html }}</div>
+    <pre>🌡️ {{ measurement.temp.temperature }}{% if measurement.temp.temperature != feels_like %}({{ feels_like }}){% endif %}{{ measurement.temp.unit }}
 🌬️ {{ measurement.wind }}
 🏋️ {{ measurement.pressure }} hPa
 🌫️ {{ measurement.humidity }}%
-☁️ {{ measurement.clouds }}%
-</pre>
+☁️ {{ measurement.clouds }}%</pre>
 </div>

--- a/app/src/lib/weather/templates/html/measurement_daily.liquid
+++ b/app/src/lib/weather/templates/html/measurement_daily.liquid
@@ -1,16 +1,11 @@
 {%  assign feels_like_min = measurement.temp.min | feels_like: measurement.humidity, measurement.wind.speed -%}
 {%  assign feels_like_max = measurement.temp.max | feels_like: measurement.humidity, measurement.wind.speed -%}
 <table>
-    <tr>
-        <td style="font-family: monospace; white-space: pre;">{{ measurement.weather[0].art.html }}</td>
-        <td>
-            <h2>{{ date }}</h2>
-            <p>Temperature: {{ measurement.temp.min }}-{{ measurement.temp.max }}</p>
-            <p>Feels like: {{ feels_like_min }}{{ measurement.temp.min.unit }}-{{ feels_like_max }}{{ measurement.temp.max.unit }}</p>
-            <p>Wind: {{ measurement.wind.HTMLString }}</p>
-            <p>Pressure: {{ measurement.pressure }} hPa</p>
-            <p>Humidity: {{ measurement.humidity }}%</p>
-            <p>Clouds: {{ measurement.clouds }}%</p>
-        </td>
-    </tr>
-</table>
+    <div style="font-family: monospace; white-space: pre;">{{ measurement.weather[0].art.html }}</div>
+    <pre>🌡️{{ measurement.temp.min }}-{{ measurement.temp.max }}
+😅 {{ feels_like_min }}{{ measurement.temp.min.unit }}-{{ feels_like_max }}{{ measurement.temp.max.unit }}
+🌬️ {{ measurement.wind }}
+🏋️ {{ measurement.pressure }} hPa
+🌫️ {{ measurement.humidity }}%
+☁️ {{ measurement.clouds }}%</pre>
+</div>

--- a/app/src/lib/weather/templates/html/weather.liquid
+++ b/app/src/lib/weather/templates/html/weather.liquid
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>coldoutsi.de - {{ location.name }}</title>
-    <link rel="Stylesheet" href="/style.css" />
+    <link rel="stylesheet" href="/style.css" />
   </head>
   <body>
     <p>Weather report: {{ location.label }}</p>
@@ -14,15 +14,20 @@
     {% for day in hourly %}
       {% assign date = day[0] -%}
       {% assign hours = day[1] -%}
-      <h3>{{ date | date: "%Y-%m-%d" }}</h3>
-      {% for hour in hours %}
-        {% render './measurement', measurement: hour, date: hour.time %}
-      {% endfor %}
+      <div class="grid hourly-grid">
+        <h3>{{ date | date: "%Y-%m-%d" }}</h3>
+        {% for hour in hours %}
+          {% render './measurement', measurement: hour, date: hour.time %}
+        {% endfor %}
+      </div>
     {% endfor %}
 
     <h2>Daily Forecast</h2>
     {% for day in daily %}
-      {% render './measurement_daily', measurement: day, date: day.time | date: "%Y-%m-%d" %}
+      <div class="grid daily-grid">
+        <h3>{{ day.time | date: "%Y-%m-%d" }}</h3>
+        {% render './measurement_daily', measurement: day %}
+      </div>
     {% endfor %}
   </body>
 </html>

--- a/app/src/lib/weather/weather-ascii.ts
+++ b/app/src/lib/weather/weather-ascii.ts
@@ -9,13 +9,13 @@ import { formatMany, RenderColours } from "./colours";
 export const artTemplates = formatMany(
   ({
     blue,
-    darkGrey,
+    darkgrey,
     grey,
     lightBlue,
-    lightGrey,
-    whiteBright,
+    lightgrey,
+    whitebright,
     yellow,
-    yellowBright,
+    yellowbright,
   }: RenderColours) => ({
     iconUnknown: dedent`
     ${grey("    .-.      ")}
@@ -25,130 +25,130 @@ export const artTemplates = formatMany(
     ${grey("      •      ")}`,
 
     iconSunny: dedent`
-    ${yellowBright("    \\ . /    ")}
-    ${yellowBright("   - .-. -   ")}
-    ${yellowBright("  ― (   ) ―  ")}
-    ${yellowBright("   . `-’ .   ")}
-    ${yellowBright("    / ' \\    ")}`,
+    ${yellowbright("    \\ . /    ")}
+    ${yellowbright("   - .-. -   ")}
+    ${yellowbright("  ― (   ) ―  ")}
+    ${yellowbright("   . `-’ .   ")}
+    ${yellowbright("    / ' \\    ")}`,
 
     iconMoon: dedent`
-    ${lightGrey("   ..-..  ")}
-    ${lightGrey(" .` o  .`.")}
-    ${lightGrey(" o~.   O )")}
-    ${lightGrey(" `..o...'/")}
-    ${lightGrey("   `'-''  ")}`,
+    ${lightgrey("   ..-..  ")}
+    ${lightgrey(" .` o  .`.")}
+    ${lightgrey(" o~.   O )")}
+    ${lightgrey(" `..o...'/")}
+    ${lightgrey("   `'-''  ")}`,
 
     iconPartlyCloudy: dedent`
-    ${yellowBright("  \\__/")}      ${lightGrey(" ")}
-    ${yellowBright("_ /  ")} ${lightGrey(".-.    ")}
-    ${yellowBright("  \\_")} ${lightGrey("(   ).  ")}
-    ${yellowBright("  /")} ${lightGrey("(___(__) ")}
-    ${lightGrey("             ")}`,
+    ${yellowbright("  \\__/")}      ${lightgrey(" ")}
+    ${yellowbright("_ /  ")} ${lightgrey(".-.    ")}
+    ${yellowbright("  \\_")} ${lightgrey("(   ).  ")}
+    ${yellowbright("  /")} ${lightgrey("(___(__) ")}
+    ${lightgrey("             ")}`,
 
     iconCloudy: dedent`
-    ${lightGrey("             ")}
-    ${lightGrey("     .--.    ")}
-    ${lightGrey("  .-(    ).  ")}
-    ${lightGrey(" (___.__)__) ")}
-    ${lightGrey("             ")}`,
+    ${lightgrey("             ")}
+    ${lightgrey("     .--.    ")}
+    ${lightgrey("  .-(    ).  ")}
+    ${lightgrey(" (___.__)__) ")}
+    ${lightgrey("             ")}`,
 
     iconVeryCloudy: dedent`
-    ${darkGrey("             ")}
-    ${darkGrey("     .--.    ")}
-    ${darkGrey("  .-(    ).  ")}
-    ${darkGrey(" (___.__)__) ")}
-    ${darkGrey("             ")}`,
+    ${darkgrey("             ")}
+    ${darkgrey("     .--.    ")}
+    ${darkgrey("  .-(    ).  ")}
+    ${darkgrey(" (___.__)__) ")}
+    ${darkgrey("             ")}`,
 
     iconLightShowers: dedent`
-  ${yellowBright(' _`/""')} ${lightGrey(".-.    ")}
-  ${yellowBright("  ,\\_")} ${lightGrey("(   ).  ")}
-  ${yellowBright("   /")} ${lightGrey("(___(__) ")}
+  ${yellowbright(' _`/""')} ${lightgrey(".-.    ")}
+  ${yellowbright("  ,\\_")} ${lightgrey("(   ).  ")}
+  ${yellowbright("   /")} ${lightgrey("(___(__) ")}
   ${lightBlue("      ‘ ‘ ‘ ‘ ")}
   ${lightBlue("     ‘ ‘ ‘ ‘  ")}`,
 
     iconHeavyShowers: dedent`
-  ${yellowBright(' _`/""')} ${darkGrey(".-.    ")}
-  ${yellowBright("  ,\\_")} ${darkGrey("(   ).  ")}
-  ${yellowBright("   /")} ${darkGrey("(___(__) ")}
+  ${yellowbright(' _`/""')} ${darkgrey(".-.    ")}
+  ${yellowbright("  ,\\_")} ${darkgrey("(   ).  ")}
+  ${yellowbright("   /")} ${darkgrey("(___(__) ")}
   ${blue("     ‚‘‚‘‚‘‚‘  ")}
   ${blue("     ‚’‚’‚’‚’  ")}`,
 
     iconLightSnowShowers: dedent`
-  ${yellowBright(' _`/""')} ${lightGrey(".-.    ")}
-  ${yellowBright("  ,\\_")} ${lightGrey("(   ).  ")}
-  ${yellowBright("   /")} ${lightGrey("(___(__) ")}
-  ${whiteBright("     *  *  * ")}
-  ${whiteBright("    *  *  *  ")}`,
+  ${yellowbright(' _`/""')} ${lightgrey(".-.    ")}
+  ${yellowbright("  ,\\_")} ${lightgrey("(   ).  ")}
+  ${yellowbright("   /")} ${lightgrey("(___(__) ")}
+  ${whitebright("     *  *  * ")}
+  ${whitebright("    *  *  *  ")}`,
 
     iconHeavySnowShowers: dedent`
-  ${yellowBright(' _`/""')} ${darkGrey(".-.    ")}
-  ${yellowBright("  ,\\_")} ${darkGrey("(   ).  ")}
-  ${yellowBright("   /")} ${darkGrey("(___(__) ")}
-  ${whiteBright("     * * * *  ")}
-  ${whiteBright("    * * * *   ")}`,
+  ${yellowbright(' _`/""')} ${darkgrey(".-.    ")}
+  ${yellowbright("  ,\\_")} ${darkgrey("(   ).  ")}
+  ${yellowbright("   /")} ${darkgrey("(___(__) ")}
+  ${whitebright("     * * * *  ")}
+  ${whitebright("    * * * *   ")}`,
 
     iconLightSleetShowers: dedent`
-  ${yellowBright(' _`/""')} ${lightGrey(".-.    ")}
-  ${yellowBright("  ,\\_")} ${lightGrey("(   ).  ")}
-  ${yellowBright("   /")} ${lightGrey("(___(__) ")}
-  ${lightBlue("     ‘ ")}${whiteBright("*")} ${lightBlue("‘ ")}${whiteBright("*")} ${lightBlue(" ")}
-  ${whiteBright("     *")} ${lightBlue("‘ ")}${whiteBright("*")} ${lightBlue("‘  ")}`,
+  ${yellowbright(' _`/""')} ${lightgrey(".-.    ")}
+  ${yellowbright("  ,\\_")} ${lightgrey("(   ).  ")}
+  ${yellowbright("   /")} ${lightgrey("(___(__) ")}
+  ${lightBlue("     ‘ ")}${whitebright("*")} ${lightBlue("‘ ")}${whitebright("*")} ${lightBlue(" ")}
+  ${whitebright("     *")} ${lightBlue("‘ ")}${whitebright("*")} ${lightBlue("‘  ")}`,
 
     iconThunderyShowers: dedent`
-  ${yellowBright(' _`/""')} ${lightGrey(".-.    ")}
-  ${yellowBright("  ,\\_")} ${lightGrey("(   ).  ")}
-  ${yellowBright("   /")} ${lightGrey("(___(__) ")}
-  ${yellowBright("     ⚡")}${lightBlue("‘‘")}${yellow("⚡")}${lightBlue("‘‘")}
+  ${yellowbright(' _`/""')} ${lightgrey(".-.    ")}
+  ${yellowbright("  ,\\_")} ${lightgrey("(   ).  ")}
+  ${yellowbright("   /")} ${lightgrey("(___(__) ")}
+  ${yellowbright("     ⚡")}${lightBlue("‘‘")}${yellow("⚡")}${lightBlue("‘‘")}
   ${lightBlue("     ‘ ‘ ‘ ‘  ")}`,
 
     iconThunderyHeavyRain: dedent`
-  ${darkGrey("     .-.     ")}
-  ${darkGrey("    (   ).   ")}
-  ${darkGrey("   (___(__)  ")}
+  ${darkgrey("     .-.     ")}
+  ${darkgrey("    (   ).   ")}
+  ${darkgrey("   (___(__)  ")}
   ${blue("  ‚‘")}${yellow("⚡")}${blue("‘‚")}${yellow("⚡")}${blue("‚‘")}
   ${blue("  ‚’‚’")}${yellow("⚡")}${blue("’‚’")}`,
 
     iconThunderySnowShowers: dedent`
-  ${yellowBright('  _`/""')} ${lightGrey(".-.")}
-  ${yellowBright("  ,\\_")} ${lightGrey("(   ).")}
-  ${yellowBright("   /")} ${lightGrey("(___(__)")}
-  ${whiteBright("     *")} ${yellow("⚡")} ${whiteBright("*")} ${yellow("⚡")} ${whiteBright("* ")}
-  ${whiteBright("    *  *  *")}`,
+  ${yellowbright('  _`/""')} ${lightgrey(".-.")}
+  ${yellowbright("  ,\\_")} ${lightgrey("(   ).")}
+  ${yellowbright("   /")} ${lightgrey("(___(__)")}
+  ${whitebright("     *")} ${yellow("⚡")} ${whitebright("*")} ${yellow("⚡")} ${whitebright("* ")}
+  ${whitebright("    *  *  *")}`,
 
     iconLightRain: dedent`
-  ${lightGrey("     .-.   ")}
-  ${lightGrey("    (   ). ")}
-  ${lightGrey("   (___(__)")}
+  ${lightgrey("     .-.   ")}
+  ${lightgrey("    (   ). ")}
+  ${lightgrey("   (___(__)")}
   ${lightBlue("    ‘ ‘ ‘ ‘")}
   ${lightBlue("   ‘ ‘ ‘ ‘ ")}`,
 
     iconHeavyRain: dedent`
-  ${darkGrey("     .-.     ")}
-  ${darkGrey("    (   ).   ")}
-  ${darkGrey("   (___(__)  ")}
+  ${darkgrey("     .-.     ")}
+  ${darkgrey("    (   ).   ")}
+  ${darkgrey("   (___(__)  ")}
   ${blue("   ‚‘‚‘‚‘‚‘   ")}
   ${blue("   ‚’‚’‚’‚’   ")}`,
 
     iconLightSnow: dedent`
-  ${lightGrey("     .-.     ")}
-  ${lightGrey("    (   ).   ")}
-  ${lightGrey("   (___(__)  ")}
-  ${whiteBright("    *  *  *  ")}
-  ${whiteBright("   *  *  *   ")}`,
+  ${lightgrey("     .-.     ")}
+  ${lightgrey("    (   ).   ")}
+  ${lightgrey("   (___(__)  ")}
+  ${whitebright("    *  *  *  ")}
+  ${whitebright("   *  *  *   ")}`,
 
     iconHeavySnow: dedent`
-  ${darkGrey("     .-.     ")}
-  ${darkGrey("    (   ).   ")}
-  ${darkGrey("   (___(__)  ")}
-  ${whiteBright("    * * * *   ")}
-  ${whiteBright("   * * * *    ")}`,
+  ${darkgrey("     .-.     ")}
+  ${darkgrey("    (   ).   ")}
+  ${darkgrey("   (___(__)  ")}
+  ${whitebright("    * * * *   ")}
+  ${whitebright("   * * * *    ")}`,
 
     iconLightSleet: dedent`
-  ${lightGrey("     .-.     ")}
-  ${lightGrey("    (   ).   ")}
-  ${lightGrey("   (___(__)  ")}
-  ${lightBlue("   ‘ ")}${whiteBright("*")} ${lightBlue("‘ ")}${whiteBright("*")} ${lightBlue("  ")}
-  ${whiteBright("   *")} ${lightBlue("‘ ")}${whiteBright("*")} ${lightBlue("‘   ")}`,
+  ${lightgrey("     .-.     ")}
+  ${lightgrey("    (   ).   ")}
+  ${lightgrey("   (___(__)  ")}
+  ${lightBlue("   ‘ ")}${whitebright("*")} ${lightBlue("‘ ")}${whitebright("*")} ${lightBlue("  ")}
+  ${whitebright("   *")} ${lightBlue("‘ ")}${whitebright("*")} ${lightBlue("‘   ")}`,
 
     iconFog: dedent`
   ${grey("             ")}

--- a/app/src/lib/weather/wind.test.ts
+++ b/app/src/lib/weather/wind.test.ts
@@ -55,7 +55,7 @@ describe("Wind Speed Conversion", () => {
   it("WindSpeedMilesPerHour HTMLString (rounded)", () => {
     const speedMPH = new WindSpeedMilesPerHour(22.3694, 22.3695, direction);
     expect(speedMPH.HTMLString).toBe(
-      '<span class="yellowBright">22.37</span>–<span class="yellowBright">22.37</span> mph ↑',
+      '<span class="yellowbright">22.37</span>–<span class="yellowbright">22.37</span> mph ↑',
     );
   });
 

--- a/app/src/lib/weather/wind.ts
+++ b/app/src/lib/weather/wind.ts
@@ -94,13 +94,13 @@ const BeaufortScale: { [key in BeaufortScaleTypes]: BeaufortScale } = {
     name: "Light Breeze",
     description:
       "Wind felt on face; leaves rustle; ordinary vanes moved by wind",
-    colour: "greenBright",
+    colour: "greenbright",
   },
   [BeaufortScaleTypes.GentleBreeze]: {
     name: "Gentle Breeze",
     description:
       "Leaves and small twigs in constant motion; light flags extended",
-    colour: "greenBright",
+    colour: "greenbright",
   },
   [BeaufortScaleTypes.ModerateBreeze]: {
     name: "Moderate Breeze",
@@ -111,41 +111,41 @@ const BeaufortScale: { [key in BeaufortScaleTypes]: BeaufortScale } = {
     name: "Fresh Breeze",
     description:
       "Small trees in leaf begin to sway; crested wavelets form on inland waters",
-    colour: "yellowBright",
+    colour: "yellowbright",
   },
   [BeaufortScaleTypes.StrongBreeze]: {
     name: "Strong Breeze",
     description:
       "Large branches in motion; whistling heard in telegraph wires; umbrellas used with difficulty",
-    colour: "yellowBright",
+    colour: "yellowbright",
   },
   [BeaufortScaleTypes.HighWind]: {
     name: "High Wind",
     description:
       "Whole trees in motion; inconvenience felt when walking against the wind",
-    colour: "yellowBright",
+    colour: "yellowbright",
   },
   [BeaufortScaleTypes.Gale]: {
     name: "Gale",
     description: "Twigs broken from trees; generally impedes progress",
-    colour: "yellowBright",
+    colour: "yellowbright",
   },
   [BeaufortScaleTypes.StrongGale]: {
     name: "Strong Gale",
     description:
       "Slight structural damage occurs (chimney pots and slates removed)",
-    colour: "redBright",
+    colour: "redbright",
   },
   [BeaufortScaleTypes.Storm]: {
     name: "Storm",
     description:
       "Seldom experienced inland; trees uprooted; considerable structural damage occurs",
-    colour: "redBright",
+    colour: "redbright",
   },
   [BeaufortScaleTypes.ViolentStorm]: {
     name: "Violent Storm",
     description: "Very rarely experienced; accompanied by widespread damage",
-    colour: "redBright",
+    colour: "redbright",
   },
   [BeaufortScaleTypes.Hurricane]: {
     name: "Hurricane",

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -1,30 +1,19 @@
-article,
-aside,
-details,
-figcaption,
-figure,
-footer,
-header,
-hgroup,
-nav,
-section,
-summary {
+.grid {
+  display: grid;
+  gap: 1rem;
+}
+
+.hourly-grid {
+  grid-template-columns: repeat(24, 1fr);
+}
+
+.daily-grid {
+  grid-template-columns: 1fr;
+}
+
+.grid > h3 {
   display: block;
-}
-
-audio,
-canvas,
-video {
-  display: inline-block;
-}
-
-audio:not([controls]) {
-  display: none;
-  height: 0;
-}
-
-[hidden] {
-  display: none;
+  grid-column: 1 / -1;
 }
 
 html {
@@ -52,145 +41,9 @@ h1 {
   font-size: 2em;
 }
 
-abbr[title] {
-  border-bottom: 1px dotted;
-}
-
-b,
-strong {
-  font-weight: bold;
-}
-
-dfn {
-  font-style: italic;
-}
-
-mark {
-  background: #ff0;
-  color: #000;
-}
-
-code,
-kbd,
-pre,
-samp {
+pre {
   font-family: monospace, serif;
   font-size: 1em;
-}
-
-pre {
-  white-space: pre-wrap;
-  word-wrap: break-word;
-}
-
-q {
-  quotes: "\201C" "\201D" "\2018" "\2019";
-}
-
-small {
-  font-size: 80%;
-}
-
-sub,
-sup {
-  font-size: 75%;
-  line-height: 0;
-  position: relative;
-  vertical-align: baseline;
-}
-
-sup {
-  top: -0.5em;
-}
-
-sub {
-  bottom: -0.25em;
-}
-
-img {
-  border: 0;
-}
-
-svg:not(:root) {
-  overflow: hidden;
-}
-
-figure {
-  margin: 0;
-}
-
-fieldset {
-  border: 1px solid #c0c0c0;
-  margin: 0 2px;
-  padding: 0.35em 0.625em 0.75em;
-}
-
-legend {
-  border: 0;
-  padding: 0;
-}
-
-button,
-input,
-select,
-textarea {
-  font-family: inherit;
-  font-size: 100%;
-  margin: 0;
-}
-
-button,
-input {
-  line-height: normal;
-}
-
-button,
-html input[type="button"],
-input[type="reset"],
-input[type="submit"] {
-  -webkit-appearance: button;
-  appearance: button;
-  cursor: pointer;
-}
-
-button[disabled],
-input[disabled] {
-  cursor: default;
-}
-
-input[type="checkbox"],
-input[type="radio"] {
-  box-sizing: border-box;
-  padding: 0;
-}
-
-input[type="search"] {
-  -webkit-appearance: textfield;
-  appearance: button;
-  -moz-box-sizing: content-box;
-  -webkit-box-sizing: content-box;
-  box-sizing: content-box;
-}
-
-input[type="search"]::-webkit-search-cancel-button,
-input[type="search"]::-webkit-search-decoration {
-  -webkit-appearance: none;
-}
-
-button::-moz-focus-inner,
-input::-moz-focus-inner {
-  border: 0;
-  padding: 0;
-}
-
-textarea {
-  overflow: auto;
-  vertical-align: top;
-}
-
-table {
-  border-collapse: collapse;
-  border-spacing: 0;
 }
 
 h1,
@@ -209,51 +62,9 @@ html {
   margin: 1em;
 }
 
-body {
-  background-color: #002b36;
-  margin: 0 auto;
-  max-width: 23cm;
-  border: 1pt solid #586e75;
-  padding: 1em;
-}
-
-code {
-  background-color: #073642;
-  padding: 2px;
-}
-
-a {
-  color: #b58900;
-}
-
-a:visited {
-  color: #cb4b16;
-}
-
-a:hover {
-  color: #cb4b16;
-}
-
-h1 {
-  color: #d33682;
-}
-
-h2,
-h3,
-h4,
-h5,
-h6 {
-  color: #859900;
-}
-
 pre {
-  background-color: #002b36;
   color: #839496;
   box-shadow: 5pt 5pt 8pt #073642;
-}
-
-pre code {
-  background-color: #002b36;
 }
 
 h1 {
@@ -280,87 +91,11 @@ h6 {
   font-size: 1.15em;
 }
 
-.tag {
-  background-color: #073642;
-  color: #d33682;
-  padding: 0 0.2em;
-}
-
-.todo,
-.next,
-.done {
-  color: #002b36;
-  background-color: #dc322f;
-  padding: 0 0.2em;
-}
-
-.tag {
-  -webkit-border-radius: 0.35em;
-  -moz-border-radius: 0.35em;
-  border-radius: 0.35em;
-}
-
-.TODO {
-  -webkit-border-radius: 0.2em;
-  -moz-border-radius: 0.2em;
-  border-radius: 0.2em;
-  background-color: #2aa198;
-}
-
-.NEXT {
-  -webkit-border-radius: 0.2em;
-  -moz-border-radius: 0.2em;
-  border-radius: 0.2em;
-  background-color: #268bd2;
-}
-
-.ACTIVE {
-  -webkit-border-radius: 0.2em;
-  -moz-border-radius: 0.2em;
-  border-radius: 0.2em;
-  background-color: #268bd2;
-}
-
-.DONE {
-  -webkit-border-radius: 0.2em;
-  -moz-border-radius: 0.2em;
-  border-radius: 0.2em;
-  background-color: #859900;
-}
-
-.WAITING {
-  -webkit-border-radius: 0.2em;
-  -moz-border-radius: 0.2em;
-  border-radius: 0.2em;
-  background-color: #cb4b16;
-}
-
-.HOLD {
-  -webkit-border-radius: 0.2em;
-  -moz-border-radius: 0.2em;
-  border-radius: 0.2em;
-  background-color: #d33682;
-}
-
-.NOTE {
-  -webkit-border-radius: 0.2em;
-  -moz-border-radius: 0.2em;
-  border-radius: 0.2em;
-  background-color: #d33682;
-}
-
-.CANCELLED {
-  -webkit-border-radius: 0.2em;
-  -moz-border-radius: 0.2em;
-  border-radius: 0.2em;
-  background-color: #859900;
-}
-
 .green {
   color: green;
 }
 
-.greenBright {
+.greenbright {
   color: limegreen;
 }
 
@@ -368,11 +103,11 @@ h6 {
   color: lightyellow;
 }
 
-.yellowBright {
+.yellowbright {
   color: yellow;
 }
 
-.redBright {
+.redbright {
   color: orangered;
 }
 
@@ -388,7 +123,7 @@ h6 {
   color: blue;
 }
 
-.lightGrey {
+.lightgrey {
   color: lightgrey;
 }
 
@@ -396,11 +131,11 @@ h6 {
   color: grey;
 }
 
-.lightBlue {
+.lightblue {
   color: lightblue;
 }
 
-.whtieBright {
+.whtiebright {
   color: white;
 }
 
@@ -409,7 +144,7 @@ h6 {
     color: lightgreen;
   }
 
-  .greenBright {
+  .greenbright {
     color: lime;
   }
 
@@ -417,11 +152,11 @@ h6 {
     color: lightyellow;
   }
 
-  .yellowBright {
+  .yellowbright {
     color: yellow;
   }
 
-  .redBright {
+  .redbright {
     color: tomato;
   }
 
@@ -437,19 +172,19 @@ h6 {
     color: lightblue;
   }
 
-  .lightGrey {
+  .lightgrey {
     color: darkgrey;
   }
 
-  .darkGrey {
+  .darkgrey {
     color: grey;
   }
 
-  .lightBlue {
+  .lightblue {
     color: blue;
   }
 
-  .whiteBright {
+  .whitebright {
     color: white;
   }
 }


### PR DESCRIPTION
The beginnings of a proper layout. We place the forecasts on one row per day using CSS grid.

Not all colours were working, because we were using e.g. `lightBlue` instead of `lightblue`. Fix that by using lowercase consistently.

Most of the CSS file was not used, so trim that down too.