### PR TITLE
Colourise wind in HTML output, and round it to two decimal places

### DIFF
--- a/app/src/lib/weather/templates/html/measurement.liquid
+++ b/app/src/lib/weather/templates/html/measurement.liquid
@@ -2,10 +2,10 @@
 
 <div>
     <p>{{ date | date: "%H:%M" }}</p>
-    <div style="font-family: monospace; white-space: pre;">{{ measurement.weather[0].art.html }}</div>
-    <pre>🌡️ {{ measurement.temp.temperature }}{% if measurement.temp.temperature != feels_like %}({{ feels_like }}){% endif %}{{ measurement.temp.unit }}
-🌬️ {{ measurement.wind }}
+    <div class="pre">{{ measurement.weather[0].art.html }}</div>
+    <div class="pre">🌡️ {{ measurement.temp.temperature }}{% if measurement.temp.temperature != feels_like %}({{ feels_like }}){% endif %}{{ measurement.temp.unit }}
+🌬️ {{ measurement.wind.HTMLString }}
 🏋️ {{ measurement.pressure }} hPa
 🌫️ {{ measurement.humidity }}%
-☁️ {{ measurement.clouds }}%</pre>
+☁️ {{ measurement.clouds }}%</div>
 </div>

--- a/app/src/lib/weather/templates/html/measurement_daily.liquid
+++ b/app/src/lib/weather/templates/html/measurement_daily.liquid
@@ -1,11 +1,11 @@
 {%  assign feels_like_min = measurement.temp.min | feels_like: measurement.humidity, measurement.wind.speed -%}
 {%  assign feels_like_max = measurement.temp.max | feels_like: measurement.humidity, measurement.wind.speed -%}
 <table>
-    <div style="font-family: monospace; white-space: pre;">{{ measurement.weather[0].art.html }}</div>
-    <pre>🌡️{{ measurement.temp.min }}-{{ measurement.temp.max }}
+    <div class="pre">{{ measurement.weather[0].art.html }}</div>
+    <div class="pre">🌡️ {{ measurement.temp.min }}-{{ measurement.temp.max }}
 😅 {{ feels_like_min }}{{ measurement.temp.min.unit }}-{{ feels_like_max }}{{ measurement.temp.max.unit }}
-🌬️ {{ measurement.wind }}
+🌬️ {{ measurement.wind.HTMLString }}
 🏋️ {{ measurement.pressure }} hPa
 🌫️ {{ measurement.humidity }}%
-☁️ {{ measurement.clouds }}%</pre>
-</div>
+☁️ {{ measurement.clouds }}%</div>
+</pre>

--- a/app/src/lib/weather/wind.test.ts
+++ b/app/src/lib/weather/wind.test.ts
@@ -25,12 +25,17 @@ describe("Wind Speed Conversion", () => {
 
   it("WindSpeedMilesPerHour toString with no gusts", () => {
     const speedMPH = new WindSpeedMilesPerHour(22.3694, undefined, direction);
-    expect(speedMPH.toString()).toBe("22.3694 mph ↑");
+    expect(speedMPH.toString()).toBe("22.37 mph ↑");
   });
 
-  it("WindSpeedMilesPerHour toString", () => {
+  it("WindSpeedMilesPerHour toString rounding to same number", () => {
     const speedMPH = new WindSpeedMilesPerHour(22.3694, 22.3695, direction);
-    expect(speedMPH.toString()).toBe("22.3694–22.3695 mph ↑");
+    expect(speedMPH.toString()).toBe("22.37 mph ↑");
+  });
+
+  it("WindSpeedMilesPerHour toString with gusts", () => {
+    const speedMPH = new WindSpeedMilesPerHour(22.3694, 22.3794, direction);
+    expect(speedMPH.toString()).toBe("22.37–22.38 mph ↑");
   });
 
   it("WindSpeedMetresPerSecond implicit toString", () => {
@@ -40,22 +45,22 @@ describe("Wind Speed Conversion", () => {
   });
 
   it("WindSpeedMilesPerHour implicit toString", () => {
-    const speedMPH = new WindSpeedMilesPerHour(22.3694, 22.3695, direction);
+    const speedMPH = new WindSpeedMilesPerHour(22.3694, 22.3795, direction);
     const message = `Wind speed is ${speedMPH}`; // Implicit toString call
-    expect(message).toBe("Wind speed is 22.3694–22.3695 mph ↑");
+    expect(message).toBe("Wind speed is 22.37–22.38 mph ↑");
   });
 
   it("WindSpeedMilesPerHour ANSIString (rounded)", () => {
-    const speedMPH = new WindSpeedMilesPerHour(22.3694, 22.3695, direction);
+    const speedMPH = new WindSpeedMilesPerHour(22.3694, 22.3795, direction);
     expect(speedMPH.ANSIString).toBe(
-      "\x1b[93m22.37\x1b[39m–\x1b[93m22.37\x1b[39m mph ↑",
+      "\x1b[93m22.37\x1b[39m–\x1b[93m22.38\x1b[39m mph ↑",
     );
   });
 
   it("WindSpeedMilesPerHour HTMLString (rounded)", () => {
-    const speedMPH = new WindSpeedMilesPerHour(22.3694, 22.3695, direction);
+    const speedMPH = new WindSpeedMilesPerHour(22.3694, 22.3795, direction);
     expect(speedMPH.HTMLString).toBe(
-      '<span class="yellowbright">22.37</span>–<span class="yellowbright">22.37</span> mph ↑',
+      '<span class="yellowbright">22.37</span>–<span class="yellowbright">22.38</span> mph ↑',
     );
   });
 

--- a/app/src/lib/weather/wind.ts
+++ b/app/src/lib/weather/wind.ts
@@ -201,8 +201,12 @@ abstract class SingleWindSpeed {
     }
   }
 
-  private get toTwoDP(): number {
+  public get toTwoDP(): number {
     return toTwoDP(this.speed);
+  }
+
+  toString(): string {
+    return this.toTwoDP.toString();
   }
 
   get ANSIString(): string {
@@ -245,15 +249,17 @@ abstract class BaseWindSpeed {
 
   toString(): string {
     const gusts =
-      this.gusts === undefined || this.gusts === this.speed
+      this.gusts === undefined ||
+      this.swsGusts?.toTwoDP === this.swsSpeed.toTwoDP
         ? ""
-        : `–${this.gusts}`;
-    return `${this.speed}${gusts} ${this.unit} ${WindDirection[this.direction]}`;
+        : `–${this.swsGusts}`;
+    return `${this.swsSpeed}${gusts} ${this.unit} ${WindDirection[this.direction]}`;
   }
 
   get ANSIString(): string {
     const gusts =
-      this.swsGusts === undefined || this.gusts === this.speed
+      this.swsGusts === undefined ||
+      this.swsGusts.toTwoDP === this.swsSpeed.toTwoDP
         ? ""
         : `–${this.swsGusts.ANSIString}`;
     return `${this.swsSpeed.ANSIString}${gusts} ${this.unit} ${WindDirection[this.direction]}`;
@@ -261,7 +267,8 @@ abstract class BaseWindSpeed {
 
   get HTMLString(): string {
     const gusts =
-      this.swsGusts === undefined || this.gusts === this.speed
+      this.swsGusts === undefined ||
+      this.swsGusts.toTwoDP === this.swsSpeed.toTwoDP
         ? ""
         : `–${this.swsGusts.HTMLString}`;
     return `${this.swsSpeed.HTMLString}${gusts} ${this.unit} ${WindDirection[this.direction]}`;

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -16,6 +16,11 @@
   grid-column: 1 / -1;
 }
 
+.pre {
+  font-family: monospace;
+  white-space: pre;
+}
+
 html {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica,
     Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";


### PR DESCRIPTION
We were outputting just the plain wind speed. There was already a method to colourise the wind speed for HTML, so call that in the template.

Additionally, make sure to always round it as we do for other numbers.