### PR TITLE
serverless-offline: Only bind to local IPv4 address

### DIFF
--- a/app/src/lib/geolocate/index.test.ts
+++ b/app/src/lib/geolocate/index.test.ts
@@ -173,20 +173,23 @@ describe("geoLocator", () => {
     );
   });
 
-  it("should return default location if localhost", async () => {
-    ddbMock.on(GetCommand).resolvesOnce({});
+  it.each<{ ip: string }>([{ ip: "127.0.0.1" }, { ip: "::1" }])(
+    "should return default location if localhost ($ip)",
+    async (ip) => {
+      ddbMock.on(GetCommand).resolvesOnce({});
 
-    const geoData = await geoLocator({ ip: "127.0.0.1" }, mockLogger);
+      const geoData = await geoLocator(ip, mockLogger);
 
-    expect(geoData).toEqual({
-      ip: "127.0.0.1",
-      location: {
-        latitude: 51.4779,
-        longitude: 0,
-      },
-    });
+      expect(geoData).toEqual({
+        ...ip,
+        location: {
+          latitude: 51.4779,
+          longitude: 0,
+        },
+      });
 
-    // ... and this one was cached
-    expect(ddbMock.commandCalls(PutCommand)).toHaveLength(1);
-  });
+      // ... and this one was cached
+      expect(ddbMock.commandCalls(PutCommand)).toHaveLength(1);
+    },
+  );
 });

--- a/app/src/lib/geolocate/index.ts
+++ b/app/src/lib/geolocate/index.ts
@@ -75,7 +75,7 @@ async function geoLocate(
   ip: string,
   logger: Logger,
 ): Promise<PartialGeoLocateResponse> {
-  if (ip === "127.0.0.1") {
+  if (ip === "127.0.0.1" || ip == "::1") {
     // If we're coming from localhost, return a default location (Royal Observatory,
     // Greenwich, London, UK).
     const defaultLatLon = {

--- a/serverless.yml
+++ b/serverless.yml
@@ -114,6 +114,9 @@ custom:
         import { createRequire as topLevelCreateRequire } from 'module';
         const require = topLevelCreateRequire(import.meta.url);
 
+  serverless-offline:
+    host: "127.0.0.1"
+
 functions:
   # Always make sure the matched paths are distinct. Put more specific paths
   # first.


### PR DESCRIPTION
Some change in the devcontainer has caused serverless-offline to start binding to `::1` when no address is specified. Looks like VS Code's auto port forwarding stuff doesn't yet work in that case, so keep on using v4.

In the geolocator we have a hardcoded result for local testing (Greenwich). This works by looking at the IP. That's easy to fix for IPv6-localhost (`::1`), so we can do that.