### PR TITLE
Preserve query string when redirecting

### DIFF
--- a/app/src/handlers/index/index.ts
+++ b/app/src/handlers/index/index.ts
@@ -44,10 +44,11 @@ function handler(
   // Redirect to `:unknown` (relative to the current page) if the client doesn't
   // accept HTML
   const rawPath = event.rawPath + (event.rawPath.endsWith("/") ? "" : "/");
+  const queryString = event.rawQueryString ? `?${event.rawQueryString}` : "";
   return Promise.resolve({
     statusCode: 302,
     headers: {
-      Location: `${rawPath}:unknown`,
+      Location: `${rawPath}:unknown${queryString}`,
     },
     body: "",
   });

--- a/app/src/handlers/unknown/unknown.ts
+++ b/app/src/handlers/unknown/unknown.ts
@@ -33,10 +33,12 @@ function handler(
   // And put it back together
   const rawPath = rawPathParts.join("/");
 
+  const queryString = event.rawQueryString ? `?${event.rawQueryString}` : "";
+
   return Promise.resolve({
     statusCode: TEMPORARY_REDIRECT,
     headers: {
-      location: `${rawPath}/${latitude}/${longitude}`,
+      location: `${rawPath}/${latitude}/${longitude}${queryString}`,
     },
   });
 }

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -17,9 +17,12 @@
           window.location.pathname +
           (window.location.pathname.endsWith("/") ? "" : "/");
 
+        const search = window.location.search;
+        const hash = window.location.hash;
+
         if (!navigator.geolocation) {
           // If Geolocation API is not supported, redirect
-          window.location.replace(`${pathWithSlash}:unknown`);
+          window.location.replace(`${pathWithSlash}:unknown${search}${hash}`);
           return;
         }
 
@@ -28,7 +31,9 @@
             const latitude = position.coords.latitude;
             const longitude = position.coords.longitude;
 
-            window.location.replace(`${pathWithSlash}${latitude}/${longitude}`);
+            window.location.replace(
+              `${pathWithSlash}${latitude}/${longitude}${search}${hash}`,
+            );
           },
 
           function (error) {
@@ -36,7 +41,7 @@
             // unknown handler, which will perform a lookup based on IP address
             // (less accurate).
             console.error("Geolocation error:", error);
-            window.location.replace(`${pathWithSlash}:unknown`);
+            window.location.replace(`${pathWithSlash}:unknown${search}${hash}`);
           },
         );
       }


### PR DESCRIPTION
When redirecting when performing geolocation, we should preserve the query string so that preferences (unit selection) are not lost.