### PR TITLE
Fixes to hourly/daily grouping

### DIFF
--- a/app/src/lib/metno/client.test.ts
+++ b/app/src/lib/metno/client.test.ts
@@ -126,7 +126,9 @@ describe("met.no client happy paths", () => {
     const day = new Date("2024-03-11T00:00:00Z");
 
     expect(weather.hourly.get(day)?.[0]?.temp.temperature).toBe(44.4);
-    expect(weather.daily[0]?.temp.max.temperature).toBe(59);
+
+    expect(weather.daily[0]?.time).toEqual(new Date("2024-03-13T00:00:00Z"));
+    expect(weather.daily[1]?.temp.max.temperature).toBe(59);
 
     expect(kvStore.size).toBe(1);
     expect(mockAxios.history["get"]).toHaveLength(1);
@@ -214,7 +216,14 @@ describe("met.no client happy paths", () => {
         new Array(24).fill(expect.any(Object)),
       ],
     ]);
-    expect(weather.daily).toHaveLength(7);
+    // An array of all dates between 2024-03-13 and 2024-03-20
+    const dates = Array.from(
+      { length: 8 },
+      // The month is 0-indexed
+      (_, i) => new Date(2024, 2, i + 13, 0, 0, 0, 0),
+    );
+    const dailyDates = weather.daily.map((d) => d.time);
+    expect(dailyDates).toEqual(dates);
   });
 });
 

--- a/app/src/lib/metno/client.ts
+++ b/app/src/lib/metno/client.ts
@@ -191,8 +191,14 @@ export class MetnoClient {
     // Hourly always includes today, and after that every other day that has 24
     // hours of data.
     const hourly = new InternMap<Date, HourlyMeasurement<"metric">[]>();
+    let dailyIterator = iterator;
     for (const [day, steps] of iterator) {
       if (day.toISOString() !== nowDayStr && steps.length !== 24) {
+        dailyIterator = (function* () {
+          yield [day, steps];
+          yield* iterator;
+        })();
+
         break;
       }
 
@@ -201,7 +207,7 @@ export class MetnoClient {
 
     // The rest is "daily", and we summarise the data for each day.
     const daily: DailyMeasurement<"metric">[] = [];
-    for (const [day, steps] of iterator) {
+    for (const [day, steps] of dailyIterator) {
       daily.push(convertDaily(day, steps));
     }
 


### PR DESCRIPTION
We had a few bugs:

1. In `metno`, we had an off-by-one error. We get the data in as an array of forecasts at particular times. We group these into "hourly" and "daily" by first grouping by day, and then by whether the day has 24 elements. This is done in two loops using a single iterator. The off-by-one error was that when we broke out of the first loop, the last element had been consumed by the iterator. We fix this by returning a custom generator which first yields that element, and then the rest as normal.
2. In `OpenWeatherMap`, we were including the same day in "hourly" and "daily". The data comes from the API slightly differently here in that is is explicitly given to us as hourly and daily data: we don't have to do this ourselves, as for `metno`. Some days are in both "hourly" and "daily" data. Since the former is higher resolution, we prefer to keep the hourly data and discard the daily data for those days.
3. We were including days in "hourly" which we didn't have 24 hours of data for. We now discard these days and use the "daily".

There's a chance we might want to revisit the "hourly must always have 24 hours" rule and do grouping differently (e.g. morning / afternoon / evening / night). But for now, let's be consistent across providers.

Note: `OpenWeatherMap` needs better tests for the grouping behaviour. In `metno` we have a real API response saved as testdata, which we use. We should do that there too.