### PR TITLE
all: Don't make handlers async unnecessarily

### DIFF
--- a/app/src/handlers/test/index.ts
+++ b/app/src/handlers/test/index.ts
@@ -46,24 +46,24 @@ async function handler(
   // HTML all of the time. So we only return HTML if the client explicitly wants
   // it.
   if (type === "text/html" && mostPreferredType !== "*/*") {
-    return Promise.resolve({
+    return {
       statusCode: OK,
       headers: {
         "cache-control": "no-store, no-cache, must-revalidate",
         "content-type": "text/html; charset=utf-8",
       },
       body: await renderTemplate(textHtmlTemplate),
-    });
+    };
   }
 
-  return Promise.resolve({
+  return {
     statusCode: OK,
     headers: {
       "cache-control": "no-store, no-cache, must-revalidate",
       "content-type": "text/plain; charset=utf-8",
     },
     body: await renderTemplate(textPlainTemplate),
-  });
+  };
 }
 
 export const testHandler = handlerFactory(handler);

--- a/app/src/handlers/unknown/unknown.ts
+++ b/app/src/handlers/unknown/unknown.ts
@@ -16,7 +16,7 @@ const { TEMPORARY_REDIRECT } = StatusCodes;
 function handler(
   event: APIGatewayProxyEventV2,
   { geoLocate }: GeoLocateContext,
-): Promise<APIGatewayProxyResultV2> {
+): APIGatewayProxyResultV2 {
   const { latitude, longitude } = geoLocate.location;
 
   // Redirect relative to the current page
@@ -35,12 +35,12 @@ function handler(
 
   const queryString = event.rawQueryString ? `?${event.rawQueryString}` : "";
 
-  return Promise.resolve({
+  return {
     statusCode: TEMPORARY_REDIRECT,
     headers: {
       location: `${rawPath}/${latitude}/${longitude}${queryString}`,
     },
-  });
+  };
 }
 
 export const unknownHandler = middy<

--- a/app/src/lib/cachecontrol/middleware.test.ts
+++ b/app/src/lib/cachecontrol/middleware.test.ts
@@ -10,12 +10,10 @@ import { LoggerContext } from "@/lib/logger";
 
 const { INTERNAL_SERVER_ERROR, NOT_FOUND, OK } = StatusCodes;
 
-function baseHandler(code: number): () => Promise<Response> {
-  return async () => {
-    return Promise.resolve({
-      statusCode: code,
-    });
-  };
+function baseHandler(code: number): () => Response {
+  return () => ({
+    statusCode: code,
+  });
 }
 
 const mockEvent = mock<APIGatewayProxyEventV2>();
@@ -53,13 +51,12 @@ describe("Cache Control Middleware", () => {
   });
 
   it("appends to existing headers", async () => {
-    const headerHandler = () =>
-      Promise.resolve({
-        statusCode: OK,
-        headers: {
-          foo: "bar",
-        },
-      });
+    const headerHandler = () => ({
+      statusCode: OK,
+      headers: {
+        foo: "bar",
+      },
+    });
 
     const response = await (
       middy()
@@ -80,7 +77,7 @@ describe("Cache Control Middleware", () => {
   });
 
   it("ignores a null response", async () => {
-    const nullHandler = () => Promise.resolve(null);
+    const nullHandler = () => null;
 
     const response = await (
       middy()
@@ -97,13 +94,12 @@ describe("Cache Control Middleware", () => {
   });
 
   it("doesn't overwrite an existing cache-control header", async () => {
-    const cacheControlHandler = () =>
-      Promise.resolve({
-        statusCode: OK,
-        headers: {
-          "cache-control": "foo",
-        },
-      });
+    const cacheControlHandler = () => ({
+      statusCode: OK,
+      headers: {
+        "cache-control": "foo",
+      },
+    });
 
     const response = await (
       middy()

--- a/app/src/lib/geocode/middleware.test.ts
+++ b/app/src/lib/geocode/middleware.test.ts
@@ -35,13 +35,11 @@ ddbMock.on(PutCommand).resolves({});
 let mockAxios: AxiosMockAdapter;
 const mockLogger = new Logger();
 
-async function baseHandler(
+function baseHandler(
   _event: APIGatewayProxyEventV2,
   context: GeoCodeContext,
-): Promise<GeoCodeData> {
-  const gc = context.geoCode;
-
-  return Promise.resolve(gc);
+): GeoCodeData {
+  return context.geoCode;
 }
 
 describe("Reverse GeoCode Middleware", () => {

--- a/app/src/lib/geolocate/middleware.test.ts
+++ b/app/src/lib/geolocate/middleware.test.ts
@@ -38,11 +38,11 @@ const mockEvent = mock<APIGatewayProxyEventV2>({
   },
 });
 
-async function baseHandler(
+function baseHandler(
   _event: APIGatewayProxyEventV2,
   context: GeoLocateContext,
-): Promise<GeoLocateContext> {
-  return Promise.resolve(context);
+): GeoLocateContext {
+  return context;
 }
 
 const middyHandler = middy()

--- a/app/src/lib/handler-factory/index.test.ts
+++ b/app/src/lib/handler-factory/index.test.ts
@@ -196,12 +196,10 @@ describe("handler factory", () => {
     geocodeHandler
       .calledWith(any(), any(), any())
       .mockImplementation(
-        async (
+        (
           _event: APIGatewayProxyEventV2 & HttpContentNegotiationEvent,
           context: GeoCodeContext,
-        ) => {
-          return Promise.resolve(context.geoCode);
-        },
+        ) => context.geoCode,
       );
 
     const handler = reverseGeocodeHandlerFactory(geocodeHandler);
@@ -243,11 +241,11 @@ describe("handler factory", () => {
     geocodeHandler
       .calledWith(any(), any(), any())
       .mockImplementation(
-        async (
+        (
           _event: APIGatewayProxyEventV2 & HttpContentNegotiationEvent,
           context: GeoCodeContext,
         ) => {
-          return Promise.resolve(context.geoCode);
+          return context.geoCode;
         },
       );
 

--- a/app/src/lib/render/middleware.test.ts
+++ b/app/src/lib/render/middleware.test.ts
@@ -9,8 +9,8 @@ import { JSONRendererOptions, Renderable, renderableMiddleware } from ".";
 
 const { NOT_ACCEPTABLE, OK } = StatusCodes;
 
-async function baseHandler(): Promise<Renderable> {
-  return Promise.resolve({
+function baseHandler(): Renderable {
+  return {
     render: {
       "application/json": (options: JSONRendererOptions) => {
         return options.pretty
@@ -22,7 +22,7 @@ async function baseHandler(): Promise<Renderable> {
         return "Hello, Plain Text!";
       },
     },
-  });
+  };
 }
 
 const middyHandler = middy()
@@ -78,7 +78,7 @@ describe("Renderable Middleware", () => {
     const nullHandler = middy()
       .use(loggerMiddleware())
       .use(renderableMiddleware())
-      .handler(async () => Promise.resolve(null)) as MiddyfiedHandler<
+      .handler(() => null) as MiddyfiedHandler<
       APIGatewayProxyEventV2,
       null,
       Error,


### PR DESCRIPTION
Handlers can be sync or async. In many cases we were making them async and wrapping the return value in a Promise. This is unnecessary and makes the code harder to read, so let's drop it.