### PR TITLE
jest: exclude generated files from coverage reports

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,11 @@
   "jest": {
     "preset": "ts-jest/presets/default-esm",
     "collectCoverage": true,
+    "coveragePathIgnorePatterns": [
+      "/node_modules/",
+      "<rootDir>/.esbuild/",
+      "<rootDir>/gen/"
+    ],
     "moduleNameMapper": {
       "^@/lib/(.*)$": "<rootDir>/app/src/lib/$1"
     },


### PR DESCRIPTION
These libraries are generated and we don't intend to test their entire surface
area. This change excludes them from the coverage reports.
