### PR TITLE
util: Utility functions for adding/removing prefixes and suffixes

### DIFF
--- a/app/src/handlers/static/indexhandler.ts
+++ b/app/src/handlers/static/indexhandler.ts
@@ -10,6 +10,7 @@ import Negotiator from "negotiator";
 
 import { cacheControlMiddleware } from "@/lib/cachecontrol";
 import { LoggerContext, loggerMiddleware } from "@/lib/logger";
+import { addPrefix, addSuffix } from "@/lib/util";
 
 import { staticFileData } from "./fileinfo";
 import { sendFileInfo } from "./static";
@@ -45,8 +46,8 @@ function handler(
 
   // Redirect to `:unknown` (relative to the current page) if the client doesn't
   // accept HTML
-  const rawPath = event.rawPath + (event.rawPath.endsWith("/") ? "" : "/");
-  const queryString = event.rawQueryString ? `?${event.rawQueryString}` : "";
+  const rawPath = addSuffix("/", event.rawPath);
+  const queryString = addPrefix("?", event.rawQueryString);
 
   return {
     statusCode: TEMPORARY_REDIRECT,

--- a/app/src/handlers/unknown/unknown.ts
+++ b/app/src/handlers/unknown/unknown.ts
@@ -8,8 +8,9 @@ import type {
 import { StatusCodes } from "http-status-codes";
 
 import { cacheControlMiddleware } from "@/lib/cachecontrol";
-import { loggerMiddleware } from "@/lib/logger";
 import { GeoLocateContext, geoLocateMiddleware } from "@/lib/geolocate";
+import { loggerMiddleware } from "@/lib/logger";
+import { addSuffix } from "@/lib/util";
 
 const { TEMPORARY_REDIRECT } = StatusCodes;
 
@@ -21,17 +22,13 @@ function handler(
 
   // Redirect relative to the current page
 
-  // Strip off any trailing slashes from the path and split it into parts
-  // (separated by slashes)
-  const rawPathParts = (
-    event.rawPath.endsWith("/") ? event.rawPath.slice(0, -1) : event.rawPath
-  ).split("/");
-
-  // Remove the last part of the path (":unknown")
-  rawPathParts.pop();
-
-  // And put it back together
-  const rawPath = rawPathParts.join("/");
+  // Strip off any trailing slashes from the path, split it into parts
+  // (separated by slashes), remove the last two parts ("/:unknown" and
+  // "/"), and then put it back together.
+  const rawPath = addSuffix("/", event.rawPath)
+    .split("/")
+    .slice(0, -2)
+    .join("/");
 
   const queryString = event.rawQueryString ? `?${event.rawQueryString}` : "";
 

--- a/app/src/lib/util/str.test.ts
+++ b/app/src/lib/util/str.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "@jest/globals";
 
-import { removePrefix } from "./str";
+import { addPrefix, addSuffix, removePrefix } from "./str";
 
 describe("string utils", () => {
   it.each<{
@@ -10,10 +10,47 @@ describe("string utils", () => {
   }>([
     { prefix: "", str: "hello", expected: "hello" },
     { prefix: "", str: "world", expected: "world" },
+    { prefix: "hello", str: "", expected: "" },
+    { prefix: "hello", str: "hello world", expected: "hello world" },
+    { prefix: "world", str: "hello world", expected: "worldhello world" },
+    { prefix: "hello", str: undefined, expected: undefined },
+  ])(
+    "add '$prefix' to the beginning of '$str'",
+    ({ prefix, str, expected }) => {
+      expect(addPrefix(prefix, str)).toEqual(expected);
+    },
+  );
+
+  it.each<{
+    prefix: string;
+    str: string | undefined;
+    expected: string | undefined;
+  }>([
+    { prefix: "", str: "hello", expected: "hello" },
+    { prefix: "", str: "world", expected: "world" },
+    { prefix: "hello", str: "", expected: "hello" },
     { prefix: "hello", str: "hello world", expected: " world" },
     { prefix: "world", str: "hello world", expected: "hello world" },
     { prefix: "hello", str: undefined, expected: undefined },
-  ])("remove '$prefix' from '$str'", ({ prefix, str, expected }) => {
-    expect(removePrefix(prefix, str)).toEqual(expected);
+  ])(
+    "remove '$prefix' from the beginning of '$str'",
+    ({ prefix, str, expected }) => {
+      expect(removePrefix(prefix, str)).toEqual(expected);
+    },
+  );
+
+  it.each<{
+    suffix: string;
+    str: string | undefined;
+    expected: string | undefined;
+  }>([
+    { suffix: "", str: "hello", expected: "hello" },
+    { suffix: "", str: "world", expected: "world" },
+    { suffix: "world", str: "", expected: "" },
+    { suffix: "world", str: "hello", expected: "helloworld" },
+    { suffix: "world", str: "hello world", expected: "hello world" },
+    { suffix: "world", str: undefined, expected: undefined },
+  ])("add '$suffix' to the end of'$str'", ({ suffix, str, expected }) => {
+    expect(addSuffix(suffix, str)).toEqual(expected);
   });
 });

--- a/app/src/lib/util/str.ts
+++ b/app/src/lib/util/str.ts
@@ -1,4 +1,47 @@
 /**
+ * A string or undefined. This is used in conjunction with overloads to export a
+ * dependently-typed signature for the functions we defined here, which return
+ * `undefined` if the input is `undefined` and a string otherwise. We use
+ * overloads because type inference in Typescript isn't powerful enough to infer
+ * the return type of a function based on the input type.
+ *
+ * {@link https://www.javiercasas.com/articles/typescript-dependent-types}
+ */
+type StringOrUndefined<T extends string | undefined> = T extends string
+  ? string
+  : T extends undefined
+    ? undefined
+    : never;
+
+/**
+ * Adds the prefix to the string. If the string already starts with the prefix,
+ * the string is returned unchanged. If the string is undefined, undefined is
+ * returned. If the string is empty, the prefix is _not added_.
+ *
+ * @param prefix The prefix to add
+ * @param str The string to add the prefix to, or undefined
+ * @returns `str` with `prefix` added, or undefined if `str` is undefined
+ */
+export function addPrefix<S extends string | undefined>(
+  prefix: string,
+  str: S,
+): StringOrUndefined<S>;
+export function addPrefix(
+  prefix: string,
+  str: string | undefined,
+): StringOrUndefined<typeof str> {
+  if (str === undefined) {
+    return undefined;
+  }
+
+  if (str === "") {
+    return str;
+  }
+
+  return str.startsWith(prefix) ? str : prefix + str;
+}
+
+/**
  * Removes the prefix from the string. If the string does not start with the
  * prefix, it is returned as is. If the string is undefined, undefined is
  * returned.
@@ -7,13 +50,49 @@
  * @param str The string to remove the prefix from, or undefined
  * @returns `str` with `prefix` removed, or undefined if `str` is undefined
  */
+export function removePrefix<S extends string | undefined>(
+  prefix: string,
+  str: S,
+): StringOrUndefined<S>;
 export function removePrefix(
   prefix: string,
   str: string | undefined,
 ): string | undefined {
-  if (!str) {
+  if (str === undefined) {
     return undefined;
   }
 
+  if (str === "") {
+    return prefix;
+  }
+
   return str.startsWith(prefix) ? str.slice(prefix.length) : str;
+}
+
+/**
+ * Adds the suffix to the string. If the string already ends with the suffix,
+ * the string is returned unchanged. If the string is undefined, undefined is
+ * returned. If the string is empty, the suffix is _not added_.
+ *
+ * @param suffix The suffix to add
+ * @param str The string to add the suffix to, or undefined
+ * @returns `str` with `suffix` added, or undefined if `str` is undefined
+ */
+export function addSuffix<S extends string | undefined>(
+  suffix: string,
+  str: S,
+): StringOrUndefined<S>;
+export function addSuffix(
+  suffix: string,
+  str: string | undefined,
+): StringOrUndefined<typeof str> {
+  if (str === undefined) {
+    return undefined;
+  }
+
+  if (str === "") {
+    return str;
+  }
+
+  return str.endsWith(suffix) ? str : str + suffix;
 }


### PR DESCRIPTION
Add `addPrefix` and `addSuffix` functions to the `util` module and use them in
the few places we were implementing this functionality manually.

Using the techniques described in [this article by Javier
Casas][dependent-types], we can have the functions take `string | undefined` and
return the same type as the input - a return type depending on an input value,
i.e. dependent types. In practice this lets us use the functions in a
non-annoying manner: if the input string is type `string` (no `| undefined`),
then we don't have to deal with the `undefined` case since the return type will
be `string`. If it's `string | undefined`, then we get `string | undefined` as
the return type, which is what we want.

[dependent-types]: https://www.javiercasas.com/articles/typescript-dependent-types
