### PR TITLE
static: Use the cache busting pattern to serve static assets

### DIFF
--- a/app/src/handlers/static/index.ts
+++ b/app/src/handlers/static/index.ts
@@ -1,4 +1,4 @@
-import { staticFileData } from "./fileinfo";
+import { staticFileData } from "@/lib/static";
 import { staticHandlerFactory } from "./static";
 
 export const staticHandler = staticHandlerFactory(staticFileData);

--- a/app/src/handlers/static/indexhandler.ts
+++ b/app/src/handlers/static/indexhandler.ts
@@ -10,9 +10,9 @@ import Negotiator from "negotiator";
 
 import { cacheControlMiddleware } from "@/lib/cachecontrol";
 import { LoggerContext, loggerMiddleware } from "@/lib/logger";
+import { staticFileData } from "@/lib/static";
 import { addPrefix, addSuffix } from "@/lib/util";
 
-import { staticFileData } from "./fileinfo";
 import { sendFileInfo } from "./static";
 
 const { TEMPORARY_REDIRECT } = StatusCodes;
@@ -41,7 +41,7 @@ function handler(
       },
     });
 
-    return sendFileInfo(log, indexHtml, event);
+    return sendFileInfo(log, indexHtml, false, event);
   }
 
   // Redirect to `:unknown` (relative to the current page) if the client doesn't

--- a/app/src/handlers/test/index.ts
+++ b/app/src/handlers/test/index.ts
@@ -11,12 +11,16 @@ import { fileURLToPath } from "url";
 import { handlerFactory } from "@/lib/handler-factory";
 import { WeatherConditions as WeatherConditionsOWM } from "@/lib/open-weather-map";
 import { WeatherConditions as WeatherConditionsMetNo } from "@/lib/metno";
+import { staticFileData } from "@/lib/static";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const engine = new Liquid({
   root: path.resolve(__dirname, "templates"),
   extname: ".liquid",
+  globals: {
+    staticFileData,
+  },
   ownPropertyOnly: false,
   trimTagRight: true,
 });

--- a/app/src/handlers/test/templates/texthtml.liquid
+++ b/app/src/handlers/test/templates/texthtml.liquid
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>coldoutsi.de - TEST</title>
-    <link rel="stylesheet" href="/style.css" />
+    <link rel="stylesheet" href="/static/style.sha256@{{ staticFileData["style.css"].hash }}.css" />
   </head>
   <body>
     <h1>OpenWeatherMap</h1>

--- a/app/src/lib/static/fileinfo.test.ts
+++ b/app/src/lib/static/fileinfo.test.ts
@@ -19,6 +19,7 @@ describe("precomputeFileData", () => {
         buffer: Buffer.from(text),
         contentType: "text/plain; charset=utf-8",
         etag: `"${sha256}"`,
+        hash: sha256,
         lastModified: expect.anything(),
         size: 5,
       },

--- a/app/src/lib/static/index.ts
+++ b/app/src/lib/static/index.ts
@@ -1,0 +1,1 @@
+export { precomputeFileData, staticFileData, staticFileInfo } from "./fileinfo";

--- a/app/src/lib/weather/templates/html/weather.liquid
+++ b/app/src/lib/weather/templates/html/weather.liquid
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>coldoutsi.de - {{ location.name }}</title>
-    <link rel="stylesheet" href="/style.css" />
+    <link rel="stylesheet" href="/static/style.sha256@{{ staticFileData["style.css"].hash }}.css" />
   </head>
   <body>
     <p>Weather report: {{ location.label }}</p>

--- a/app/src/lib/weather/weather.ts
+++ b/app/src/lib/weather/weather.ts
@@ -13,6 +13,7 @@ import {
   RenderableType,
   RendererOptionsMap,
 } from "@/lib/render";
+import { staticFileData } from "@/lib/static";
 
 import {
   Temperature,
@@ -28,6 +29,9 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const engine = new Liquid({
   root: path.resolve(__dirname, "../../lib/weather/templates"),
   extname: ".liquid",
+  globals: {
+    staticFileData,
+  },
   ownPropertyOnly: false,
 });
 

--- a/serverless.yml
+++ b/serverless.yml
@@ -131,14 +131,6 @@ functions:
           path: /favicon.ico
           method: GET
 
-      - httpApi:
-          path: /style.css
-          method: GET
-
-      - httpApi:
-          path: /test.txt
-          method: GET
-
   index:
     handler: ./app/src/handlers/static/index.indexHandler
     events:


### PR DESCRIPTION
We had a problem previously. Taking the `style.css` file as an example: since
the file is served at `/style.css` and with `cache-control` headers set to
`public, s-maxage=60`, browsers and caches will cache it. Even though we set an
ETag and a `Last-Modified` header, the browser will not check for changes until
the cache expires. This means that if we update the file and the HTML
accordingly, users could be using the old CSS for a while, and therefore see a
broken layout.

There's a pattern called "cache busting" that solves this problem. The idea is
to change the URL of the file every time it changes. This way, the browser will
be forced to download the new file. We do this by using a scheme like

```
/static/style.sha256@<hash>.css
```

for the URL of the file. The `<hash>` part is the SHA256 hash of the file, which
is the same as is in the ETag.

Implement this in the `static` handler by having it handle URLs in this format,
serving the underlying file if it exists and the hash matches. If the hash does
not match, the handler returns a 404.

Update the Liquid templates accordingly, to generate URLs with hashes. For that
we needed to move `fileInfo` to a library module, so that the static handler and
the weather handler can both use it, since they both need to know the hashes of
the static assets.
