### PR TITLE
linting: Add eslint-plugin-no-relative-import-paths

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,5 +1,6 @@
 import eslint from "@eslint/js";
 import jestPlugin from "eslint-plugin-jest";
+import eslingPluginNoRelativeImportPaths from "eslint-plugin-no-relative-import-paths";
 import eslintPluginPrettierRecommended from "eslint-plugin-prettier/recommended";
 import unicornPlugin from "eslint-plugin-unicorn";
 import globals from "globals";
@@ -9,6 +10,7 @@ export default tseslint.config(
   {
     plugins: {
       ["@typescript-eslint"]: tseslint.plugin,
+      ["no-relative-import-paths"]: eslingPluginNoRelativeImportPaths,
       ["jest"]: jestPlugin,
       ["unicorn"]: unicornPlugin,
     },
@@ -67,6 +69,11 @@ export default tseslint.config(
       ],
       "@typescript-eslint/restrict-template-expressions": "off",
       "dot-notation": "off",
+
+      "no-relative-import-paths/no-relative-import-paths": [
+        "error",
+        { allowSameFolder: true },
+      ],
 
       "unicorn/no-typeof-undefined": "error",
     },

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-jest": "^28.5.0",
     "eslint-plugin-n": "^17.7.0",
+    "eslint-plugin-no-relative-import-paths": "^1.5.4",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-prettier": "^5.1.3",
     "eslint-plugin-unicorn": "^53.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7739,6 +7739,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"eslint-plugin-no-relative-import-paths@npm:^1.5.4":
+  version: 1.5.4
+  resolution: "eslint-plugin-no-relative-import-paths@npm:1.5.4"
+  checksum: 10c0/93fde7e0aca874874d2a4a544f2e090d30a7c06bbd1280e228cd7a85358c9f2de6ef4b7a449f29befd995f9dc78545968a06e911b693c2ca4ac0af5bc197f76a
+  languageName: node
+  linkType: hard
+
 "eslint-plugin-node@npm:^11.1.0":
   version: 11.1.0
   resolution: "eslint-plugin-node@npm:11.1.0"
@@ -12061,6 +12068,7 @@ __metadata:
     eslint-config-prettier: "npm:^9.1.0"
     eslint-plugin-jest: "npm:^28.5.0"
     eslint-plugin-n: "npm:^17.7.0"
+    eslint-plugin-no-relative-import-paths: "npm:^1.5.4"
     eslint-plugin-node: "npm:^11.1.0"
     eslint-plugin-prettier: "npm:^5.1.3"
     eslint-plugin-unicorn: "npm:^53.0.0"


### PR DESCRIPTION
This prevents us from using relative imports like `../lib/foo`, since we have an
alias `@/lib/foo` which we prefer to use.
