### PR TITLE
ci: Read node version from package.json

### DIFF
--- a/.github/workflows/test-lint.yml
+++ b/.github/workflows/test-lint.yml
@@ -18,9 +18,8 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
         with:
-          node-version: "20"
+          node-version-file: "package.json"
           cache: "yarn"
-          cache-dependency-path: "./yarn.lock"
 
       - name: Install dependencies
         run: yarn install --immutable

--- a/package.json
+++ b/package.json
@@ -1,5 +1,8 @@
 {
   "private": true,
+  "engines": {
+    "node": "22"
+  },
   "workspaces": {
     "packages": [
       "app",


### PR DESCRIPTION
This means we only need to update the version in one place, and it will be used
in the CI workflow. Also drop `cache-dependency-file`, since
`actions/setup-node` will find `yarn.lock` by default anyway.
