### PR TITLE
api gateway routes: Don't try to use greedy path for `/static`

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -124,7 +124,7 @@ functions:
     handler: ./app/src/handlers/static/index.staticHandler
     events:
       - httpApi:
-          path: /static/{path+}
+          path: /static/{path}
           method: GET
 
       - httpApi:


### PR DESCRIPTION
This is broken somehow. I tried using `{proxy+}` too and that didn't work
either. Requests always end up at the `/{lat}/{lon}` route. We don't actually
need to match subdirectories here, so we can use a single level path.
