### PR TITLE
infra: Drop the S3 bucket

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -236,18 +236,3 @@ resources:
         TimeToLiveSpecification:
           AttributeName: ttl
           Enabled: true
-
-    StaticWebsiteBucket:
-      Type: AWS::S3::Bucket
-      Properties:
-        BucketName: coldoutsi.de-static-content-${sls:stage}
-        # Only accessible by CloudFront
-        AccessControl: Private
-        WebsiteConfiguration:
-          IndexDocument: index.html
-          ErrorDocument: error.html
-        Tags:
-          - Key: Name
-            Value: "coldoutsi.de"
-          - Key: Environment
-            Value: ${sls:stage}


### PR DESCRIPTION
We're bundling the assets in the Lambda, so no need for it right now.
