### PR TITLE
geolocate, index.html: Round lat/lon to 2 decimal places

### DIFF
--- a/app/src/lib/geolocate/index.test.ts
+++ b/app/src/lib/geolocate/index.test.ts
@@ -15,11 +15,11 @@ import { mockClient } from "aws-sdk-client-mock";
 import "aws-sdk-client-mock-jest";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
-import { mock } from "jest-mock-extended";
 import { StatusCodes } from "http-status-codes";
+import { mock } from "jest-mock-extended";
 
-import { GeoLocateError, geoLocator } from ".";
 import type { Logger } from "@/lib/logger";
+import { GeoLocateError, geoLocator } from ".";
 
 const { BAD_REQUEST, OK } = StatusCodes;
 
@@ -183,7 +183,7 @@ describe("geoLocator", () => {
       expect(geoData).toEqual({
         ...ip,
         location: {
-          latitude: 51.4779,
+          latitude: 51.48,
           longitude: 0,
         },
       });

--- a/app/src/lib/geolocate/index.ts
+++ b/app/src/lib/geolocate/index.ts
@@ -1,11 +1,12 @@
 import { PutCommandOutput } from "@aws-sdk/lib-dynamodb";
+import axios from "axios";
 
 import { GeoJSApiFactory, Geolocate200ResponseInner } from "@internal/geojs";
 
 import { retryableAxios } from "@/lib/axios";
 import { dynamoDbDocClient } from "@/lib/dynamodb";
 import type { Logger } from "@/lib/logger";
-import axios from "axios";
+import { toTwoDP } from "@/lib/util";
 
 type PartialGeoLocateResponse = Partial<Geolocate200ResponseInner>;
 
@@ -133,12 +134,12 @@ export async function geoLocator(
 
   const { latitude, longitude } = geoData;
 
-  const lat = Number(latitude);
+  const lat = toTwoDP(Number(latitude));
   if (Number.isNaN(lat)) {
     throw new GeoLocateError(`Invalid latitude for ${ip}: ${latitude}`);
   }
 
-  const lon = Number(longitude);
+  const lon = toTwoDP(Number(longitude));
   if (Number.isNaN(lon)) {
     throw new GeoLocateError(`Invalid longitude for ${ip}: ${longitude}`);
   }

--- a/app/src/lib/geolocate/middleware.test.ts
+++ b/app/src/lib/geolocate/middleware.test.ts
@@ -79,8 +79,8 @@ describe("GeoLocate Middleware", () => {
     expect(response.geoLocate).toEqual({
       ip: "1.2.3.4",
       location: {
-        latitude: 47.6062,
-        longitude: 122.3321,
+        latitude: 47.61,
+        longitude: 122.33,
       },
     });
   });
@@ -313,8 +313,8 @@ describe("GeoLocate Middleware", () => {
     expect(response.geoLocate).toEqual({
       ip: "1.2.3.4",
       location: {
-        latitude: 47.6062,
-        longitude: 122.3321,
+        latitude: 47.61,
+        longitude: 122.33,
       },
     });
   });

--- a/app/src/lib/geolocate/middleware.ts
+++ b/app/src/lib/geolocate/middleware.ts
@@ -1,12 +1,13 @@
-import { MiddlewareObj } from "@middy/core";
-import type { APIGatewayProxyEventV2, Context } from "aws-lambda";
 import {
   BadRequest,
   InternalServerError,
   UnprocessableContent,
 } from "@curveball/http-errors";
+import { MiddlewareObj } from "@middy/core";
+import type { APIGatewayProxyEventV2, Context } from "aws-lambda";
 
 import type { LoggerContext } from "@/lib/logger";
+import { toTwoDP } from "@/lib/util";
 import { GeoLocate, GeoLocateError, geoLocator } from ".";
 
 export interface GeoLocateContext extends Context {
@@ -38,8 +39,8 @@ export function geoLocateMiddleware<TResult>(): MiddlewareObj<
       const ip = event.requestContext.http.sourceIp;
 
       if (latParam && lonParam) {
-        const latitude = Number(latParam);
-        const longitude = Number(lonParam);
+        const latitude = toTwoDP(Number(latParam));
+        const longitude = toTwoDP(Number(lonParam));
 
         if (Number.isNaN(latitude)) {
           throw new BadRequest(`Invalid lat: ${latParam}`);
@@ -69,8 +70,8 @@ export function geoLocateMiddleware<TResult>(): MiddlewareObj<
       const cfLongitude = event.headers["cloudfront-viewer-longitude"];
 
       if (cfLatitude && cfLongitude) {
-        const latitude = Number(cfLatitude);
-        const longitude = Number(cfLongitude);
+        const latitude = toTwoDP(Number(cfLatitude));
+        const longitude = toTwoDP(Number(cfLongitude));
 
         if (!(Number.isNaN(latitude) || Number.isNaN(longitude))) {
           log.debug("Using lat/lon from CloudFront headers", {

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -28,8 +28,8 @@
 
         navigator.geolocation.getCurrentPosition(
           function (position) {
-            const latitude = position.coords.latitude;
-            const longitude = position.coords.longitude;
+            const latitude = position.coords.latitude.toFixed(2);
+            const longitude = position.coords.longitude.toFixed(2);
 
             window.location.replace(
               `${pathWithSlash}${latitude}/${longitude}${search}${hash}`,


### PR DESCRIPTION
We don't need to be more precise than this - weather data is not available at such a high resolution. This will improve cache hit rates.