### PR TITLE
unknown: Only cache in private caches

### DIFF
--- a/app/src/handlers/unknown/unknown.ts
+++ b/app/src/handlers/unknown/unknown.ts
@@ -35,6 +35,7 @@ function handler(
   return {
     statusCode: TEMPORARY_REDIRECT,
     headers: {
+      "cache-control": "private, max-age=60",
       location: `${rawPath}/${latitude}/${longitude}${queryString}`,
     },
   };


### PR DESCRIPTION
This redirect is specific to the user's location, so we don't want it to be cached in shared caches.