### PR TITLE
Add packages to pnmp-workspace.yaml

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+packages:
+  - app
+  - gen/*


### PR DESCRIPTION
Seems like Dependabot requires this to be filled in, even though pnpm finds all packages by itself.