### PR TITLE
geolocate: Round latitude/longitude to 2 decimal places

### DIFF
--- a/app/src/handlers/unknown/unknown.test.ts
+++ b/app/src/handlers/unknown/unknown.test.ts
@@ -43,7 +43,15 @@ describe("unknown handler", () => {
       expected: "/",
     },
     {
+      prefix: "/:unknown/",
+      expected: "/",
+    },
+    {
       prefix: "/metno/:unknown",
+      expected: "/metno/",
+    },
+    {
+      prefix: "/metno/:unknown/",
       expected: "/metno/",
     },
   ])(

--- a/app/src/handlers/unknown/unknown.ts
+++ b/app/src/handlers/unknown/unknown.ts
@@ -10,7 +10,7 @@ import { StatusCodes } from "http-status-codes";
 import { cacheControlMiddleware } from "@/lib/cachecontrol";
 import { GeoLocateContext, geoLocateMiddleware } from "@/lib/geolocate";
 import { loggerMiddleware } from "@/lib/logger";
-import { addSuffix } from "@/lib/util";
+import { removePathParts } from "@/lib/util";
 
 const { TEMPORARY_REDIRECT } = StatusCodes;
 
@@ -22,13 +22,8 @@ function handler(
 
   // Redirect relative to the current page
 
-  // Strip off any trailing slashes from the path, split it into parts
-  // (separated by slashes), remove the last two parts ("/:unknown" and
-  // "/"), and then put it back together.
-  const rawPath = addSuffix("/", event.rawPath)
-    .split("/")
-    .slice(0, -2)
-    .join("/");
+  // Remove the last part ("/:unknown") from the path
+  const rawPath = removePathParts(1, event.rawPath);
 
   const queryString = event.rawQueryString ? `?${event.rawQueryString}` : "";
 

--- a/app/src/lib/geocode/middleware.test.ts
+++ b/app/src/lib/geocode/middleware.test.ts
@@ -32,7 +32,7 @@ const ddbMock = mockClient(DynamoDBDocumentClient);
 ddbMock.on(GetCommand).resolves({});
 ddbMock.on(PutCommand).resolves({});
 
-let mockAxios: AxiosMockAdapter;
+const mockAxios = new AxiosMockAdapter(axios);
 const mockLogger = new Logger();
 
 function baseHandler(
@@ -66,7 +66,7 @@ describe("Reverse GeoCode Middleware", () => {
   geoLocateContext.logger = mockLogger;
 
   beforeEach(() => {
-    mockAxios = new AxiosMockAdapter(axios);
+    mockAxios.reset();
   });
 
   it("reverse geocodes", async () => {
@@ -141,7 +141,7 @@ describe("Geocode Middleware", () => {
   geoLocateContext.logger = mockLogger;
 
   beforeEach(() => {
-    mockAxios = new AxiosMockAdapter(axios);
+    mockAxios.reset();
     mockReset(geoLocateContext);
   });
 

--- a/app/src/lib/geolocate/middleware.ts
+++ b/app/src/lib/geolocate/middleware.ts
@@ -4,14 +4,134 @@ import {
   UnprocessableContent,
 } from "@curveball/http-errors";
 import { MiddlewareObj } from "@middy/core";
-import type { APIGatewayProxyEventV2, Context } from "aws-lambda";
+import type {
+  APIGatewayProxyEventV2,
+  APIGatewayProxyResultV2,
+  Context,
+} from "aws-lambda";
+import { StatusCodes } from "http-status-codes";
 
-import type { LoggerContext } from "@/lib/logger";
-import { toTwoDP } from "@/lib/util";
+import type { Logger, LoggerContext } from "@/lib/logger";
+import { toTwoDP, removePathParts } from "@/lib/util";
 import { GeoLocate, GeoLocateError, geoLocator } from ".";
+
+const { PERMANENT_REDIRECT } = StatusCodes;
 
 export interface GeoLocateContext extends Context {
   geoLocate: GeoLocate;
+}
+
+export const thirtyDays = 60 * 60 * 24 * 30;
+
+function roundRedirect(
+  log: Logger,
+  latitude: number,
+  longitude: number,
+  event: APIGatewayProxyEventV2,
+): APIGatewayProxyResultV2 {
+  const base = removePathParts(2, event.rawPath);
+  const queryString = event.rawQueryString ? `?${event.rawQueryString}` : "";
+
+  log.info("lat/lon greater than 2dp, redirecting");
+
+  return {
+    statusCode: PERMANENT_REDIRECT,
+    headers: {
+      "cache-control": `public, max-age=${thirtyDays}, immutable`,
+      location: `${base}/${latitude}/${longitude}${queryString}`,
+    },
+  };
+}
+
+function handleLatLon(
+  log: Logger,
+  event: APIGatewayProxyEventV2,
+  context: GeoLocateContext,
+  latParam: string,
+  lonParam: string,
+): APIGatewayProxyResultV2 | undefined {
+  const latNumber = Number(latParam);
+  const lonNumber = Number(lonParam);
+
+  const latitude = toTwoDP(latNumber);
+  const longitude = toTwoDP(lonNumber);
+
+  if (Number.isNaN(latitude)) {
+    throw new BadRequest(`Invalid latitude parameter: ${latParam}`);
+  }
+
+  if (Number.isNaN(longitude)) {
+    throw new BadRequest(`Invalid longitude parameter: ${lonParam}`);
+  }
+
+  log = log.createChild({
+    persistentLogAttributes: {
+      lat: latitude,
+      lon: longitude,
+    },
+  });
+
+  // Round lat/lon to 2dp of accuracy for improved caching
+  if (latNumber !== latitude || lonNumber !== longitude) {
+    return roundRedirect(
+      log.createChild({
+        persistentLogAttributes: {
+          givenLat: latNumber,
+          givenLon: lonNumber,
+        },
+      }),
+      latitude,
+      longitude,
+      event,
+    );
+  }
+
+  log.debug("Using lat/lon from query parameters");
+
+  context.geoLocate = {
+    ip: event.requestContext.http.sourceIp,
+    location: { latitude, longitude },
+  };
+
+  return;
+}
+
+function handleCloudFront(
+  log: Logger,
+  latHeader: string,
+  lonHeader: string,
+  ip: string,
+  context: GeoLocateContext,
+): boolean {
+  const lat = Number(latHeader);
+  if (Number.isNaN(lat)) {
+    log.warn("Received invalid latitude from CloudFront Headers", {
+      latHeader,
+    });
+
+    return false;
+  }
+
+  const lon = Number(lonHeader);
+  if (Number.isNaN(lon)) {
+    log.warn("Received invalid longitude from CloudFront Headers", {
+      lonHeader,
+    });
+
+    return false;
+  }
+
+  const latitude = toTwoDP(lat);
+  const longitude = toTwoDP(lon);
+
+  log.debug("Using lat/lon from CloudFront headers", {
+    lat: latitude,
+    lon: longitude,
+  });
+
+  context.geoLocate = { ip, location: { latitude, longitude } };
+
+  return true;
 }
 
 // Middleware to geolocate based on IP or use given lat/lon.
@@ -22,10 +142,15 @@ export function geoLocateMiddleware<TResult>(): MiddlewareObj<
   LoggerContext & GeoLocateContext
 > {
   return {
-    before: async ({ event, context }) => {
+    before: async ({
+      event,
+      context,
+    }): Promise<APIGatewayProxyResultV2 | undefined> => {
+      const ip = event.requestContext.http.sourceIp;
       const log = context.logger.createChild({
         persistentLogAttributes: {
           middleware: "geoLocate",
+          ip,
         },
       });
 
@@ -36,29 +161,8 @@ export function geoLocateMiddleware<TResult>(): MiddlewareObj<
       const latParam = pathParameters["lat"];
       const lonParam = pathParameters["lon"];
 
-      const ip = event.requestContext.http.sourceIp;
-
       if (latParam && lonParam) {
-        const latitude = toTwoDP(Number(latParam));
-        const longitude = toTwoDP(Number(lonParam));
-
-        if (Number.isNaN(latitude)) {
-          throw new BadRequest(`Invalid lat: ${latParam}`);
-        }
-
-        if (Number.isNaN(longitude)) {
-          throw new BadRequest(`Invalid lon: ${lonParam}`);
-        }
-
-        log.debug("Using lat/lon from query parameters", {
-          latitude,
-          longitude,
-          ip,
-        });
-
-        context.geoLocate = { ip, location: { latitude, longitude } };
-
-        return;
+        return handleLatLon(log, event, context, latParam, lonParam);
       }
 
       if ((latParam !== undefined) !== (lonParam !== undefined)) {
@@ -70,17 +174,7 @@ export function geoLocateMiddleware<TResult>(): MiddlewareObj<
       const cfLongitude = event.headers["cloudfront-viewer-longitude"];
 
       if (cfLatitude && cfLongitude) {
-        const latitude = toTwoDP(Number(cfLatitude));
-        const longitude = toTwoDP(Number(cfLongitude));
-
-        if (!(Number.isNaN(latitude) || Number.isNaN(longitude))) {
-          log.debug("Using lat/lon from CloudFront headers", {
-            lat: latitude,
-            lon: longitude,
-            ip,
-          });
-          context.geoLocate = { ip, location: { latitude, longitude } };
-
+        if (handleCloudFront(log, cfLatitude, cfLongitude, ip, context)) {
           return;
         }
       }
@@ -96,6 +190,8 @@ export function geoLocateMiddleware<TResult>(): MiddlewareObj<
 
         throw new InternalServerError(`Failed to geolocate ${ip}: ${error}`);
       }
+
+      return;
     },
   };
 }

--- a/app/src/lib/handler-factory/index.ts
+++ b/app/src/lib/handler-factory/index.ts
@@ -22,7 +22,8 @@ export type { Event as HttpContentNegotiationEvent } from "@middy/http-content-n
 export type { Event as HttpHeaderNormalizerEvent } from "@middy/http-header-normalizer";
 
 // copied from @middy/core as it's not exported
-// The AWS provided Handler type uses void | Promise<TResult> so we have no choice but to follow and suppress the linter warning
+// The AWS provided Handler type uses void | Promise<TResult> so we have no
+// choice but to follow and suppress the linter warning
 type MiddyInputHandler<
   TEvent,
   TResult,

--- a/app/src/lib/util/str.test.ts
+++ b/app/src/lib/util/str.test.ts
@@ -1,6 +1,12 @@
 import { describe, it, expect } from "@jest/globals";
 
-import { addPrefix, addSuffix, removePrefix } from "./str";
+import {
+  addPrefix,
+  addSuffix,
+  removePathParts,
+  removePrefix,
+  removeSuffixes,
+} from "./str";
 
 describe("string utils", () => {
   it.each<{
@@ -28,10 +34,12 @@ describe("string utils", () => {
   }>([
     { prefix: "", str: "hello", expected: "hello" },
     { prefix: "", str: "world", expected: "world" },
-    { prefix: "hello", str: "", expected: "hello" },
-    { prefix: "hello", str: "hello world", expected: " world" },
+    { prefix: "hello", str: "", expected: "" },
+    { prefix: "hello", str: "hello world", expected: "world" },
     { prefix: "world", str: "hello world", expected: "hello world" },
     { prefix: "hello", str: undefined, expected: undefined },
+    { prefix: "", str: " hello", expected: "hello" },
+    { prefix: "foo", str: " hello", expected: "hello" },
   ])(
     "remove '$prefix' from the beginning of '$str'",
     ({ prefix, str, expected }) => {
@@ -52,5 +60,71 @@ describe("string utils", () => {
     { suffix: "world", str: undefined, expected: undefined },
   ])("add '$suffix' to the end of'$str'", ({ suffix, str, expected }) => {
     expect(addSuffix(suffix, str)).toEqual(expected);
+  });
+
+  it.each<{
+    suffix: string;
+    str: string | undefined;
+    maxOccurrences?: number;
+    expected: string | undefined;
+  }>([
+    { suffix: "", str: "hello", expected: "hello" },
+    { suffix: "", str: "world", expected: "world" },
+    { suffix: "world", str: "", expected: "" },
+    { suffix: "world", str: "hello", expected: "hello" },
+    { suffix: "world", str: "hello world", expected: "hello" },
+    { suffix: "world", str: undefined, expected: undefined },
+    {
+      suffix: "world",
+      str: "hello world",
+      maxOccurrences: 1,
+      expected: "hello",
+    },
+    {
+      suffix: "world",
+      str: "hello world",
+      maxOccurrences: 2,
+      expected: "hello",
+    },
+    {
+      suffix: "world",
+      str: "hello world world",
+      maxOccurrences: 1,
+      expected: "hello world",
+    },
+    {
+      suffix: "world",
+      str: "hello world world",
+      maxOccurrences: 2,
+      expected: "hello",
+    },
+    {
+      suffix: "",
+      str: "hello ",
+      expected: "hello",
+    },
+  ])(
+    "remove $maxOccurrences '$suffix' from the end of '$str'",
+    ({ suffix, str, expected, maxOccurrences }) => {
+      expect(removeSuffixes(suffix, str, maxOccurrences)).toEqual(expected);
+    },
+  );
+});
+
+describe("HTTP path utils", () => {
+  it.each<{
+    n_parts: number;
+    path: string | undefined;
+    expected: string | undefined;
+  }>([
+    { n_parts: 0, path: "hello/world", expected: "hello/world" },
+    { n_parts: 1, path: "hello/world", expected: "hello" },
+    { n_parts: 2, path: "hello/world", expected: "" },
+    { n_parts: 0, path: "hello/world/", expected: "hello/world" },
+    { n_parts: 1, path: "hello/world/", expected: "hello" },
+    { n_parts: 1, path: "hello/world/////   ", expected: "hello" },
+    { n_parts: 1337, path: undefined, expected: undefined },
+  ])("remove $n_parts from the end of $path", ({ n_parts, path, expected }) => {
+    expect(removePathParts(n_parts, path)).toEqual(expected);
   });
 });

--- a/app/src/lib/util/str.ts
+++ b/app/src/lib/util/str.ts
@@ -42,9 +42,8 @@ export function addPrefix(
 }
 
 /**
- * Removes the prefix from the string. If the string does not start with the
- * prefix, it is returned as is. If the string is undefined, undefined is
- * returned.
+ * Removes the prefix from the string. The returned string will be trimmed of
+ * leading whitespace. If the string is undefined, undefined is returned.
  *
  * @param prefix The prefix to remove
  * @param str The string to remove the prefix from, or undefined
@@ -62,11 +61,11 @@ export function removePrefix(
     return undefined;
   }
 
-  if (str === "") {
-    return prefix;
+  if (str === "" || prefix === "") {
+    return str.trimStart();
   }
 
-  return str.startsWith(prefix) ? str.slice(prefix.length) : str;
+  return (str.startsWith(prefix) ? str.slice(prefix.length) : str).trimStart();
 }
 
 /**
@@ -95,4 +94,80 @@ export function addSuffix(
   }
 
   return str.endsWith(suffix) ? str : str + suffix;
+}
+
+/**
+ * Removes up to `maxOccurrences` of the suffix from the string. The end of the
+ * returned string will be trimmed of trailing whitespace. If the string is
+ * undefined, undefined is returned.
+ *
+ * @param suffix The suffix to remove
+ * @param str The string to remove the suffix from, or undefined
+ * @param maxOccurrences The maximum number of occurrences of `suffix` to
+ * remove. If undefined, all occurrences are removed.
+ * @returns `str` with `suffix` removed, or undefined if `str` is undefined
+ */
+export function removeSuffixes<S extends string | undefined>(
+  suffix: string,
+  str: S,
+  maxOccurrences?: number,
+): StringOrUndefined<S>;
+export function removeSuffixes(
+  suffix: string,
+  str: string | undefined,
+  maxOccurrences?: number,
+): string | undefined {
+  if (str === undefined) {
+    return undefined;
+  }
+
+  if (str === "" || suffix === "") {
+    return str.trimEnd();
+  }
+
+  for (
+    let i = 0;
+    str.endsWith(suffix) && i < (maxOccurrences ?? Infinity);
+    i++
+  ) {
+    str = str.slice(0, -suffix.length).trimEnd();
+  }
+
+  return str;
+}
+
+/**
+ * Removes a number of path parts from the end of the HTTP path given in `str`.
+ * Trailing slashes and trailing whitespace will not be preserved. If the string
+ * is undefined, undefined is returned. If the string is empty, or doesn't have
+ * enough parts to remove, an empty string is returned.
+ *
+ * @param n_parts The number of parts to remove
+ * @param str The path to remove parts from, or undefined
+ * @returns `str` with `n_parts` parts removed, or undefined if `str` is undefined
+ */
+export function removePathParts<S extends string | undefined>(
+  n_parts: number,
+  str: S,
+): StringOrUndefined<S>;
+export function removePathParts(
+  n_parts: number,
+  str: string | undefined,
+): string | undefined {
+  if (str === undefined) {
+    return undefined;
+  }
+
+  const strStripped = removeSuffixes("/", str.trimEnd());
+  if (n_parts <= 0) {
+    return strStripped;
+  }
+
+  const parts = strStripped.split("/");
+
+  if (parts.length <= n_parts) {
+    return "";
+  }
+
+  return parts.slice(0, -n_parts).join("/");
 }


### PR DESCRIPTION
Weather isn't returned at a more granular level than this. If we truncate the input coordinates to 2 decimal places, we can improve our cache efficiency.
