### PR TITLE
geolocate: Reduce duplication in middleware tests

### DIFF
--- a/app/src/lib/geolocate/middleware.ts
+++ b/app/src/lib/geolocate/middleware.ts
@@ -158,14 +158,14 @@ export function geoLocateMiddleware<TResult>(): MiddlewareObj<
 
       pathParameters = pathParameters ?? {};
 
-      const latParam = pathParameters["lat"];
-      const lonParam = pathParameters["lon"];
+      const latParam = pathParameters["lat"] ?? "";
+      const lonParam = pathParameters["lon"] ?? "";
 
-      if (latParam && lonParam) {
+      if (latParam !== "" && lonParam !== "") {
         return handleLatLon(log, event, context, latParam, lonParam);
       }
 
-      if ((latParam !== undefined) !== (lonParam !== undefined)) {
+      if ((latParam === "") !== (lonParam === "")) {
         throw new BadRequest("If either lat or lon is specified, both must be");
       }
 


### PR DESCRIPTION
There were a lot of repeated patterns in the tests. This change removes most of that.

Additionally, we now always convert the path parameters (lat and lon) to an empty string if either is missing. Since we're behind an API Gateway in production, we should be able to expect that this is the case for real requests --- therefore, it's better if the tests behave like this too and we don't handle `undefined` there.
